### PR TITLE
Develop (#32)

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -161,7 +161,7 @@ class SecurityHeaders
             ])),
             'style-src-elem '.implode(' ', array_filter([
                 "'self'",
-                $isLocalEnvironment ? "'unsafe-inline'" : "'nonce-{$nonce}'",
+                "'unsafe-inline'",
                 'https://fonts.googleapis.com',
                 'https://fonts.bunny.net',
                 $isLocalEnvironment ? 'http://0.0.0.0:5173 http://127.0.0.1:5173 http://localhost:5173' : null,

--- a/app/Modules/Pagi/Services/PagiProfileService.php
+++ b/app/Modules/Pagi/Services/PagiProfileService.php
@@ -78,7 +78,7 @@ class PagiProfileService
         $names = $this->extractCollaboratorNames($projectsCollection);
         $preloadedUsers = [];
         if (! empty($names)) {
-            $preloadedUsers = User::whereIn('name', $names)
+            $preloadedUsers = User::query()->whereIn('name', $names, 'and', false)
                 ->select(['id', 'name', 'pagi_username', 'foto_path'])
                 ->get()
                 ->keyBy('name')
@@ -286,7 +286,7 @@ class PagiProfileService
      */
     public function checkUsername(string $username, int $currentUserId): array
     {
-        $exists = User::where('pagi_username', $username)
+        $exists = User::query()->where('pagi_username', $username)
             ->where('id', '!=', $currentUserId)
             ->exists();
 
@@ -303,7 +303,7 @@ class PagiProfileService
         ];
 
         // One query to check which candidates are already taken
-        $taken = User::whereIn('pagi_username', $candidates)
+        $taken = User::query()->whereIn('pagi_username', $candidates, 'and', false)
             ->pluck('pagi_username')
             ->flip()
             ->all();

--- a/app/Modules/Wims/Controllers/Admin/PlacementController.php
+++ b/app/Modules/Wims/Controllers/Admin/PlacementController.php
@@ -18,8 +18,7 @@ class PlacementController extends Controller
         private readonly PlacementIndexService $placementIndexService,
         private readonly PlacementActionService $placementActionService,
         private readonly PlacementWorkflowService $placementWorkflowService,
-    ) {
-    }
+    ) {}
 
     public function index(Request $request): Response
     {

--- a/app/Modules/Wims/Services/Mahasiswa/Attendance/AttendanceExportService.php
+++ b/app/Modules/Wims/Services/Mahasiswa/Attendance/AttendanceExportService.php
@@ -105,9 +105,9 @@ class AttendanceExportService
     private function renderPdfWithIsolatedCompiledViews(string $view, array $data, string $fileName)
     {
         $compiledPath = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR)
-            . DIRECTORY_SEPARATOR
-            . 'wims-pdf-views-'
-            . Str::uuid();
+            .DIRECTORY_SEPARATOR
+            .'wims-pdf-views-'
+            .Str::uuid();
 
         File::ensureDirectoryExists($compiledPath);
 

--- a/app/Modules/Wims/Services/Mahasiswa/Logbook/LogbookExportService.php
+++ b/app/Modules/Wims/Services/Mahasiswa/Logbook/LogbookExportService.php
@@ -75,7 +75,7 @@ class LogbookExportService
                 'mentor' => $registration->perusahaan?->user?->name ?? '-',
             ],
             'rows' => $rows,
-        ], 'logbook-pkl-periode-terakhir-' . now()->format('Y-m-d') . '.pdf');
+        ], 'logbook-pkl-periode-terakhir-'.now()->format('Y-m-d').'.pdf');
     }
 
     /**
@@ -85,9 +85,9 @@ class LogbookExportService
     private function renderPdfWithIsolatedCompiledViews(string $view, array $data, string $fileName)
     {
         $compiledPath = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR)
-            . DIRECTORY_SEPARATOR
-            . 'wims-pdf-views-'
-            . Str::uuid();
+            .DIRECTORY_SEPARATOR
+            .'wims-pdf-views-'
+            .Str::uuid();
 
         File::ensureDirectoryExists($compiledPath);
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -141,14 +141,24 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->statefulApi();
 
-        // SEC-007: Restrict trusted proxies to Cloudflare's published IP ranges only.
+        // SEC-007: Restrict trusted proxies to Cloudflare's published IP ranges + Docker internal.
         // Using '*' (wildcard) allows any X-Forwarded-For header, enabling IP spoofing.
         // These ranges are Cloudflare's official IPv4 + IPv6 ranges (last updated 2025).
         // Reference: https://www.cloudflare.com/ips/
+        //
+        // Docker/Traefik internal ranges are included so that Dokploy's Traefik reverse proxy
+        // can properly forward X-Forwarded-Proto: https to Laravel. Without these, Laravel
+        // treats all requests as HTTP even when accessed via HTTPS, breaking signed URL
+        // validation (403) and CSP nonce logic.
         $middleware->trustProxies(at: implode(',', [
             '127.0.0.1',
             '::1',
-            // IPv4
+            // Docker internal networks (Traefik / Dokploy reverse proxy)
+            // Default Docker bridge: 172.17.0.0/16
+            // Docker Compose default: 172.16.0.0/12 (covers 172.16–172.31)
+            '172.16.0.0/12',
+            '10.0.0.0/8',
+            // Cloudflare IPv4
             '173.245.48.0/20',
             '103.21.244.0/22',
             '103.22.200.0/22',
@@ -164,7 +174,7 @@ return Application::configure(basePath: dirname(__DIR__))
             '104.24.0.0/14',
             '172.64.0.0/13',
             '131.0.72.0/22',
-            // IPv6
+            // Cloudflare IPv6
             '2400:cb00::/32',
             '2606:4700::/32',
             '2803:f800::/32',


### PR DESCRIPTION
* perf(pagi): optimize query count, explore people payload limit, and inertia lazy loading

* fix(fast): unify kop surat logo source

* feat(fast): commit remaining integration changes

* refactor(fast): align ui with projek-fast

* fix(fast): refine document preview and layout integration

* security: implement security audit fixes (COOP/CORP/COEP/HSTS, robots.txt, secure cookie default)

* fix(database): avoid SoftDeletes scope issue on JenisSurat queries in migrations

* fix(fast,wims): remove stale nim_nip queries

* fix(security): relax CSP for local style injection

* refactor(wims): streamline company form and feedback

* refactor(wims): move storage to private disk

* fix(wims): resolve profile avatar proxy urls

* fix(wims): improve registration submit feedback

* fix(wims): restore registration route helper

* refactor(fast): harden private storage cleanup

* fix: remove style nonce from CSP to prevent blocking inline styles

* fix: resolve lint errors and failing test cases in CI pipeline

* ci: use biome format --check instead of --write in workflow

* ci: fix biome check command and commit pint formatted PHP files

* fix(wims): stabilize pdf downloads and ui consistency

* fix: use User::query() to fix IDE false-positive warning in PagiProfileService

* fix: supply explicit arguments for whereIn to fix IDE stub errors and apply Pint formatting

* fix: allow unsafe-inline in style-src-elem directive to prevent blocking Vue dynamic style elements

* fix: trust Docker/Traefik internal network for Dokploy proxy

Add 172.16.0.0/12 and 10.0.0.0/8 to trustProxies so Traefik's X-Forwarded-Proto: https header is respected by Laravel.

Without this, Laravel treated all requests as HTTP even when accessed via HTTPS, causing:
- 403 on signed image URLs (signature mismatch http vs https)
- CSP nonce logic errors (isSecure evaluated to false)

---------