### PR TITLE
fix(fast): sync mahasiswa dashboard routes

### DIFF
--- a/app/Modules/Coreportal/Controllers/PortalController.php
+++ b/app/Modules/Coreportal/Controllers/PortalController.php
@@ -202,8 +202,8 @@ class PortalController extends Controller
                 'admin', 'super-admin', 'super_admin', 'admin-universitas', 'admin-akademik', 'prodi' => 'admin.dashboard',
                 'kaprodi', 'dekan' => 'approval.dashboard',
                 'dosen' => 'dosen.dashboard',
-                'mahasiswa', 'alumni' => 'fast.user.dashboard',
-                default => 'fast.user.dashboard',
+                'mahasiswa', 'alumni' => 'mahasiswa.dashboard',
+                default => 'mahasiswa.dashboard',
             };
         }
 

--- a/app/Modules/Fast/Controllers/Shared/User/DashboardController.php
+++ b/app/Modules/Fast/Controllers/Shared/User/DashboardController.php
@@ -132,7 +132,7 @@ class DashboardController extends Controller
 
     protected function pageName(): string
     {
-        return 'fast/user/Dashboard';
+        return 'mahasiswa/Dashboard';
     }
 
     protected function submissionRouteName(): string
@@ -142,7 +142,7 @@ class DashboardController extends Controller
 
     protected function basePath(): string
     {
-        return '/fast/user';
+        return '/mahasiswa';
     }
 
     protected function visibleSubmissionJenisSuratQuery($user): Builder

--- a/app/Modules/Fast/Controllers/Shared/User/SubmissionController.php
+++ b/app/Modules/Fast/Controllers/Shared/User/SubmissionController.php
@@ -226,17 +226,17 @@ class SubmissionController extends Controller
 
     protected function pageName(): string
     {
-        return 'fast/user/Ajukan';
+        return 'mahasiswa/Ajukan';
     }
 
     protected function basePath(): string
     {
-        return '/fast/user';
+        return '/mahasiswa';
     }
 
     protected function dashboardRouteName(): string
     {
-        return 'fast.user.dashboard';
+        return 'mahasiswa.dashboard';
     }
 
     protected function visibleSubmissionJenisSuratQuery($user): Builder

--- a/resources/js/actions/App/Http/Controllers/Api/SuratController.ts
+++ b/resources/js/actions/App/Http/Controllers/Api/SuratController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../wayfinder'
 /**
 * @see \App\Http\Controllers\Api\SuratController::index
-* @see app/Http/Controllers/Api/SuratController.php:21
-* @route '/api/fast/surat'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:22
+ * @route '/api/fast/surat'
+ */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ index.definition = {
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::index
-* @see app/Http/Controllers/Api/SuratController.php:21
-* @route '/api/fast/surat'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:22
+ * @route '/api/fast/surat'
+ */
 index.url = (options?: RouteQueryOptions) => {
     return index.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::index
-* @see app/Http/Controllers/Api/SuratController.php:21
-* @route '/api/fast/surat'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:22
+ * @route '/api/fast/surat'
+ */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Http\Controllers\Api\SuratController::index
-* @see app/Http/Controllers/Api/SuratController.php:21
-* @route '/api/fast/surat'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:22
+ * @route '/api/fast/surat'
+ */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Http\Controllers\Api\SuratController::index
+ * @see app/Http/Controllers/Api/SuratController.php:22
+ * @route '/api/fast/surat'
+ */
+    const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Http\Controllers\Api\SuratController::index
+ * @see app/Http/Controllers/Api/SuratController.php:22
+ * @route '/api/fast/surat'
+ */
+        indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Http\Controllers\Api\SuratController::index
+ * @see app/Http/Controllers/Api/SuratController.php:22
+ * @route '/api/fast/surat'
+ */
+        indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index.form = indexForm
 /**
 * @see \App\Http\Controllers\Api\SuratController::store
-* @see app/Http/Controllers/Api/SuratController.php:60
-* @route '/api/fast/surat'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:61
+ * @route '/api/fast/surat'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -60,28 +94,49 @@ store.definition = {
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::store
-* @see app/Http/Controllers/Api/SuratController.php:60
-* @route '/api/fast/surat'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:61
+ * @route '/api/fast/surat'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::store
-* @see app/Http/Controllers/Api/SuratController.php:60
-* @route '/api/fast/surat'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:61
+ * @route '/api/fast/surat'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Http\Controllers\Api\SuratController::store
+ * @see app/Http/Controllers/Api/SuratController.php:61
+ * @route '/api/fast/surat'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\Api\SuratController::store
+ * @see app/Http/Controllers/Api/SuratController.php:61
+ * @route '/api/fast/surat'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 /**
 * @see \App\Http\Controllers\Api\SuratController::show
-* @see app/Http/Controllers/Api/SuratController.php:74
-* @route '/api/fast/surat/{surat}'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:75
+ * @route '/api/fast/surat/{surat}'
+ */
 export const show = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
@@ -94,31 +149,31 @@ show.definition = {
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::show
-* @see app/Http/Controllers/Api/SuratController.php:74
-* @route '/api/fast/surat/{surat}'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:75
+ * @route '/api/fast/surat/{surat}'
+ */
 show.url = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { surat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { surat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { surat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            surat: args[0],
-        }
+                    surat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        surat: typeof args.surat === 'object'
-        ? args.surat.id
-        : args.surat,
-    }
+                        surat: typeof args.surat === 'object'
+                ? args.surat.id
+                : args.surat,
+                }
 
     return show.definition.url
             .replace('{surat}', parsedArgs.surat.toString())
@@ -127,29 +182,63 @@ show.url = (args: { surat: number | { id: number } } | [surat: number | { id: nu
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::show
-* @see app/Http/Controllers/Api/SuratController.php:74
-* @route '/api/fast/surat/{surat}'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:75
+ * @route '/api/fast/surat/{surat}'
+ */
 show.get = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Http\Controllers\Api\SuratController::show
-* @see app/Http/Controllers/Api/SuratController.php:74
-* @route '/api/fast/surat/{surat}'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:75
+ * @route '/api/fast/surat/{surat}'
+ */
 show.head = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Http\Controllers\Api\SuratController::show
+ * @see app/Http/Controllers/Api/SuratController.php:75
+ * @route '/api/fast/surat/{surat}'
+ */
+    const showForm = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Http\Controllers\Api\SuratController::show
+ * @see app/Http/Controllers/Api/SuratController.php:75
+ * @route '/api/fast/surat/{surat}'
+ */
+        showForm.get = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Http\Controllers\Api\SuratController::show
+ * @see app/Http/Controllers/Api/SuratController.php:75
+ * @route '/api/fast/surat/{surat}'
+ */
+        showForm.head = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 /**
 * @see \App\Http\Controllers\Api\SuratController::adminValidate
-* @see app/Http/Controllers/Api/SuratController.php:110
-* @route '/api/fast/surat/{surat}/admin-validation'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:111
+ * @route '/api/fast/surat/{surat}/admin-validation'
+ */
 export const adminValidate = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: adminValidate.url(args, options),
     method: 'post',
@@ -162,31 +251,31 @@ adminValidate.definition = {
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::adminValidate
-* @see app/Http/Controllers/Api/SuratController.php:110
-* @route '/api/fast/surat/{surat}/admin-validation'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:111
+ * @route '/api/fast/surat/{surat}/admin-validation'
+ */
 adminValidate.url = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { surat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { surat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { surat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            surat: args[0],
-        }
+                    surat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        surat: typeof args.surat === 'object'
-        ? args.surat.id
-        : args.surat,
-    }
+                        surat: typeof args.surat === 'object'
+                ? args.surat.id
+                : args.surat,
+                }
 
     return adminValidate.definition.url
             .replace('{surat}', parsedArgs.surat.toString())
@@ -195,19 +284,40 @@ adminValidate.url = (args: { surat: number | { id: number } } | [surat: number |
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::adminValidate
-* @see app/Http/Controllers/Api/SuratController.php:110
-* @route '/api/fast/surat/{surat}/admin-validation'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:111
+ * @route '/api/fast/surat/{surat}/admin-validation'
+ */
 adminValidate.post = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: adminValidate.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Http\Controllers\Api\SuratController::adminValidate
+ * @see app/Http/Controllers/Api/SuratController.php:111
+ * @route '/api/fast/surat/{surat}/admin-validation'
+ */
+    const adminValidateForm = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: adminValidate.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\Api\SuratController::adminValidate
+ * @see app/Http/Controllers/Api/SuratController.php:111
+ * @route '/api/fast/surat/{surat}/admin-validation'
+ */
+        adminValidateForm.post = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: adminValidate.url(args, options),
+            method: 'post',
+        })
+    
+    adminValidate.form = adminValidateForm
 /**
 * @see \App\Http\Controllers\Api\SuratController::approve
-* @see app/Http/Controllers/Api/SuratController.php:122
-* @route '/api/fast/surat/{surat}/approval'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:123
+ * @route '/api/fast/surat/{surat}/approval'
+ */
 export const approve = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: approve.url(args, options),
     method: 'post',
@@ -220,31 +330,31 @@ approve.definition = {
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::approve
-* @see app/Http/Controllers/Api/SuratController.php:122
-* @route '/api/fast/surat/{surat}/approval'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:123
+ * @route '/api/fast/surat/{surat}/approval'
+ */
 approve.url = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { surat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { surat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { surat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            surat: args[0],
-        }
+                    surat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        surat: typeof args.surat === 'object'
-        ? args.surat.id
-        : args.surat,
-    }
+                        surat: typeof args.surat === 'object'
+                ? args.surat.id
+                : args.surat,
+                }
 
     return approve.definition.url
             .replace('{surat}', parsedArgs.surat.toString())
@@ -253,19 +363,40 @@ approve.url = (args: { surat: number | { id: number } } | [surat: number | { id:
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::approve
-* @see app/Http/Controllers/Api/SuratController.php:122
-* @route '/api/fast/surat/{surat}/approval'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:123
+ * @route '/api/fast/surat/{surat}/approval'
+ */
 approve.post = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: approve.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Http\Controllers\Api\SuratController::approve
+ * @see app/Http/Controllers/Api/SuratController.php:123
+ * @route '/api/fast/surat/{surat}/approval'
+ */
+    const approveForm = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: approve.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\Api\SuratController::approve
+ * @see app/Http/Controllers/Api/SuratController.php:123
+ * @route '/api/fast/surat/{surat}/approval'
+ */
+        approveForm.post = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: approve.url(args, options),
+            method: 'post',
+        })
+    
+    approve.form = approveForm
 /**
 * @see \App\Http\Controllers\Api\SuratController::generateDocument
-* @see app/Http/Controllers/Api/SuratController.php:136
-* @route '/api/fast/surat/{surat}/generate-document'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:137
+ * @route '/api/fast/surat/{surat}/generate-document'
+ */
 export const generateDocument = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: generateDocument.url(args, options),
     method: 'post',
@@ -278,31 +409,31 @@ generateDocument.definition = {
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::generateDocument
-* @see app/Http/Controllers/Api/SuratController.php:136
-* @route '/api/fast/surat/{surat}/generate-document'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:137
+ * @route '/api/fast/surat/{surat}/generate-document'
+ */
 generateDocument.url = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { surat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { surat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { surat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            surat: args[0],
-        }
+                    surat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        surat: typeof args.surat === 'object'
-        ? args.surat.id
-        : args.surat,
-    }
+                        surat: typeof args.surat === 'object'
+                ? args.surat.id
+                : args.surat,
+                }
 
     return generateDocument.definition.url
             .replace('{surat}', parsedArgs.surat.toString())
@@ -311,14 +442,35 @@ generateDocument.url = (args: { surat: number | { id: number } } | [surat: numbe
 
 /**
 * @see \App\Http\Controllers\Api\SuratController::generateDocument
-* @see app/Http/Controllers/Api/SuratController.php:136
-* @route '/api/fast/surat/{surat}/generate-document'
-*/
+ * @see app/Http/Controllers/Api/SuratController.php:137
+ * @route '/api/fast/surat/{surat}/generate-document'
+ */
 generateDocument.post = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: generateDocument.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Http\Controllers\Api\SuratController::generateDocument
+ * @see app/Http/Controllers/Api/SuratController.php:137
+ * @route '/api/fast/surat/{surat}/generate-document'
+ */
+    const generateDocumentForm = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: generateDocument.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Http\Controllers\Api\SuratController::generateDocument
+ * @see app/Http/Controllers/Api/SuratController.php:137
+ * @route '/api/fast/surat/{surat}/generate-document'
+ */
+        generateDocumentForm.post = (args: { surat: number | { id: number } } | [surat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: generateDocument.url(args, options),
+            method: 'post',
+        })
+    
+    generateDocument.form = generateDocumentForm
 const SuratController = { index, store, show, adminValidate, approve, generateDocument }
 
 export default SuratController

--- a/resources/js/actions/App/Http/Controllers/Api/index.ts
+++ b/resources/js/actions/App/Http/Controllers/Api/index.ts
@@ -1,5 +1,4 @@
 import SuratController from './SuratController'
-
 const Api = {
     SuratController: Object.assign(SuratController, SuratController),
 }

--- a/resources/js/actions/App/Http/Controllers/index.ts
+++ b/resources/js/actions/App/Http/Controllers/index.ts
@@ -1,9 +1,8 @@
 import Api from './Api'
 import QrVerificationController from './QrVerificationController'
-
 const Controllers = {
     Api: Object.assign(Api, Api),
-    QrVerificationController: Object.assign(QrVerificationController, QrVerificationController),
+QrVerificationController: Object.assign(QrVerificationController, QrVerificationController),
 }
 
 export default Controllers

--- a/resources/js/actions/App/Http/index.ts
+++ b/resources/js/actions/App/Http/index.ts
@@ -1,5 +1,4 @@
 import Controllers from './Controllers'
-
 const Http = {
     Controllers: Object.assign(Controllers, Controllers),
 }

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/ArchiveController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/ArchiveController.ts
@@ -1,47 +1,249 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
-* @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:16
-* @route '/admin/archive'
-*/
-export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/admin/archive'
+ */
+const indexd26c433e7c04b4f951b322dc72094283 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexd26c433e7c04b4f951b322dc72094283.url(options),
     method: 'get',
 })
 
-index.definition = {
+indexd26c433e7c04b4f951b322dc72094283.definition = {
     methods: ["get","head"],
     url: '/admin/archive',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
-* @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:16
-* @route '/admin/archive'
-*/
-index.url = (options?: RouteQueryOptions) => {
-    return index.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/admin/archive'
+ */
+indexd26c433e7c04b4f951b322dc72094283.url = (options?: RouteQueryOptions) => {
+    return indexd26c433e7c04b4f951b322dc72094283.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
-* @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:16
-* @route '/admin/archive'
-*/
-index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/admin/archive'
+ */
+indexd26c433e7c04b4f951b322dc72094283.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexd26c433e7c04b4f951b322dc72094283.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/admin/archive'
+ */
+indexd26c433e7c04b4f951b322dc72094283.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexd26c433e7c04b4f951b322dc72094283.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/admin/archive'
+ */
+    const indexd26c433e7c04b4f951b322dc72094283Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexd26c433e7c04b4f951b322dc72094283.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/admin/archive'
+ */
+        indexd26c433e7c04b4f951b322dc72094283Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexd26c433e7c04b4f951b322dc72094283.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/admin/archive'
+ */
+        indexd26c433e7c04b4f951b322dc72094283Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexd26c433e7c04b4f951b322dc72094283.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexd26c433e7c04b4f951b322dc72094283.form = indexd26c433e7c04b4f951b322dc72094283Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/kaprodi/admin/archive'
+ */
+const index9e9cbe0bf95a93bbab76f1f8695f1b2a = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index9e9cbe0bf95a93bbab76f1f8695f1b2a.url(options),
     method: 'get',
 })
 
+index9e9cbe0bf95a93bbab76f1f8695f1b2a.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/archive',
+} satisfies RouteDefinition<["get","head"]>
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
-* @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:16
-* @route '/admin/archive'
-*/
-index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/kaprodi/admin/archive'
+ */
+index9e9cbe0bf95a93bbab76f1f8695f1b2a.url = (options?: RouteQueryOptions) => {
+    return index9e9cbe0bf95a93bbab76f1f8695f1b2a.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/kaprodi/admin/archive'
+ */
+index9e9cbe0bf95a93bbab76f1f8695f1b2a.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index9e9cbe0bf95a93bbab76f1f8695f1b2a.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/kaprodi/admin/archive'
+ */
+index9e9cbe0bf95a93bbab76f1f8695f1b2a.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index9e9cbe0bf95a93bbab76f1f8695f1b2a.url(options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/kaprodi/admin/archive'
+ */
+    const index9e9cbe0bf95a93bbab76f1f8695f1b2aForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index9e9cbe0bf95a93bbab76f1f8695f1b2a.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/kaprodi/admin/archive'
+ */
+        index9e9cbe0bf95a93bbab76f1f8695f1b2aForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index9e9cbe0bf95a93bbab76f1f8695f1b2a.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/kaprodi/admin/archive'
+ */
+        index9e9cbe0bf95a93bbab76f1f8695f1b2aForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index9e9cbe0bf95a93bbab76f1f8695f1b2a.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index9e9cbe0bf95a93bbab76f1f8695f1b2a.form = index9e9cbe0bf95a93bbab76f1f8695f1b2aForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/dekan/admin/archive'
+ */
+const index432e5c86134de767f315c647346c40bb = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index432e5c86134de767f315c647346c40bb.url(options),
+    method: 'get',
+})
+
+index432e5c86134de767f315c647346c40bb.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/archive',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/dekan/admin/archive'
+ */
+index432e5c86134de767f315c647346c40bb.url = (options?: RouteQueryOptions) => {
+    return index432e5c86134de767f315c647346c40bb.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/dekan/admin/archive'
+ */
+index432e5c86134de767f315c647346c40bb.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index432e5c86134de767f315c647346c40bb.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/dekan/admin/archive'
+ */
+index432e5c86134de767f315c647346c40bb.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index432e5c86134de767f315c647346c40bb.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/dekan/admin/archive'
+ */
+    const index432e5c86134de767f315c647346c40bbForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index432e5c86134de767f315c647346c40bb.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/dekan/admin/archive'
+ */
+        index432e5c86134de767f315c647346c40bbForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index432e5c86134de767f315c647346c40bb.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\ArchiveController::index
+ * @see app/Modules/Fast/Controllers/Admin/ArchiveController.php:17
+ * @route '/dekan/admin/archive'
+ */
+        index432e5c86134de767f315c647346c40bbForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index432e5c86134de767f315c647346c40bb.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index432e5c86134de767f315c647346c40bb.form = index432e5c86134de767f315c647346c40bbForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\ArchiveController::index, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `index['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const index = {
+    '/admin/archive': indexd26c433e7c04b4f951b322dc72094283,
+    '/kaprodi/admin/archive': index9e9cbe0bf95a93bbab76f1f8695f1b2a,
+    '/dekan/admin/archive': index432e5c86134de767f315c647346c40bb,
+}
 
 const ArchiveController = { index }
 

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/CategoryController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/CategoryController.ts
@@ -1,197 +1,984 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
-* @route '/admin/categories'
-*/
-export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/admin/categories'
+ */
+const index377c0d45be70873e0ecaf350cc14e1cf = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index377c0d45be70873e0ecaf350cc14e1cf.url(options),
     method: 'get',
 })
 
-index.definition = {
+index377c0d45be70873e0ecaf350cc14e1cf.definition = {
     methods: ["get","head"],
     url: '/admin/categories',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
-* @route '/admin/categories'
-*/
-index.url = (options?: RouteQueryOptions) => {
-    return index.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/admin/categories'
+ */
+index377c0d45be70873e0ecaf350cc14e1cf.url = (options?: RouteQueryOptions) => {
+    return index377c0d45be70873e0ecaf350cc14e1cf.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
-* @route '/admin/categories'
-*/
-index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/admin/categories'
+ */
+index377c0d45be70873e0ecaf350cc14e1cf.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index377c0d45be70873e0ecaf350cc14e1cf.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
-* @route '/admin/categories'
-*/
-index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/admin/categories'
+ */
+index377c0d45be70873e0ecaf350cc14e1cf.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index377c0d45be70873e0ecaf350cc14e1cf.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/admin/categories'
+ */
+    const index377c0d45be70873e0ecaf350cc14e1cfForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index377c0d45be70873e0ecaf350cc14e1cf.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/admin/categories'
+ */
+        index377c0d45be70873e0ecaf350cc14e1cfForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index377c0d45be70873e0ecaf350cc14e1cf.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/admin/categories'
+ */
+        index377c0d45be70873e0ecaf350cc14e1cfForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index377c0d45be70873e0ecaf350cc14e1cf.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index377c0d45be70873e0ecaf350cc14e1cf.form = index377c0d45be70873e0ecaf350cc14e1cfForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/kaprodi/admin/categories'
+ */
+const index8b07aa3b1c2796b83a14462ab0656d15 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index8b07aa3b1c2796b83a14462ab0656d15.url(options),
+    method: 'get',
+})
+
+index8b07aa3b1c2796b83a14462ab0656d15.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/categories',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/kaprodi/admin/categories'
+ */
+index8b07aa3b1c2796b83a14462ab0656d15.url = (options?: RouteQueryOptions) => {
+    return index8b07aa3b1c2796b83a14462ab0656d15.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/kaprodi/admin/categories'
+ */
+index8b07aa3b1c2796b83a14462ab0656d15.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index8b07aa3b1c2796b83a14462ab0656d15.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/kaprodi/admin/categories'
+ */
+index8b07aa3b1c2796b83a14462ab0656d15.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index8b07aa3b1c2796b83a14462ab0656d15.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/kaprodi/admin/categories'
+ */
+    const index8b07aa3b1c2796b83a14462ab0656d15Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index8b07aa3b1c2796b83a14462ab0656d15.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/kaprodi/admin/categories'
+ */
+        index8b07aa3b1c2796b83a14462ab0656d15Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index8b07aa3b1c2796b83a14462ab0656d15.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/kaprodi/admin/categories'
+ */
+        index8b07aa3b1c2796b83a14462ab0656d15Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index8b07aa3b1c2796b83a14462ab0656d15.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index8b07aa3b1c2796b83a14462ab0656d15.form = index8b07aa3b1c2796b83a14462ab0656d15Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/dekan/admin/categories'
+ */
+const indexab103ac7bafaf67a1bab6c43d4f96ad8 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexab103ac7bafaf67a1bab6c43d4f96ad8.url(options),
+    method: 'get',
+})
+
+indexab103ac7bafaf67a1bab6c43d4f96ad8.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/categories',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/dekan/admin/categories'
+ */
+indexab103ac7bafaf67a1bab6c43d4f96ad8.url = (options?: RouteQueryOptions) => {
+    return indexab103ac7bafaf67a1bab6c43d4f96ad8.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/dekan/admin/categories'
+ */
+indexab103ac7bafaf67a1bab6c43d4f96ad8.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexab103ac7bafaf67a1bab6c43d4f96ad8.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/dekan/admin/categories'
+ */
+indexab103ac7bafaf67a1bab6c43d4f96ad8.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexab103ac7bafaf67a1bab6c43d4f96ad8.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/dekan/admin/categories'
+ */
+    const indexab103ac7bafaf67a1bab6c43d4f96ad8Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexab103ac7bafaf67a1bab6c43d4f96ad8.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/dekan/admin/categories'
+ */
+        indexab103ac7bafaf67a1bab6c43d4f96ad8Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexab103ac7bafaf67a1bab6c43d4f96ad8.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:16
+ * @route '/dekan/admin/categories'
+ */
+        indexab103ac7bafaf67a1bab6c43d4f96ad8Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexab103ac7bafaf67a1bab6c43d4f96ad8.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexab103ac7bafaf67a1bab6c43d4f96ad8.form = indexab103ac7bafaf67a1bab6c43d4f96ad8Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\CategoryController::index, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `index['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const index = {
+    '/admin/categories': index377c0d45be70873e0ecaf350cc14e1cf,
+    '/kaprodi/admin/categories': index8b07aa3b1c2796b83a14462ab0656d15,
+    '/dekan/admin/categories': indexab103ac7bafaf67a1bab6c43d4f96ad8,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:23
-* @route '/admin/categories'
-*/
-export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: store.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/admin/categories'
+ */
+const store377c0d45be70873e0ecaf350cc14e1cf = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store377c0d45be70873e0ecaf350cc14e1cf.url(options),
     method: 'post',
 })
 
-store.definition = {
+store377c0d45be70873e0ecaf350cc14e1cf.definition = {
     methods: ["post"],
     url: '/admin/categories',
 } satisfies RouteDefinition<["post"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:23
-* @route '/admin/categories'
-*/
-store.url = (options?: RouteQueryOptions) => {
-    return store.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/admin/categories'
+ */
+store377c0d45be70873e0ecaf350cc14e1cf.url = (options?: RouteQueryOptions) => {
+    return store377c0d45be70873e0ecaf350cc14e1cf.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:23
-* @route '/admin/categories'
-*/
-store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: store.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/admin/categories'
+ */
+store377c0d45be70873e0ecaf350cc14e1cf.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store377c0d45be70873e0ecaf350cc14e1cf.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/admin/categories'
+ */
+    const store377c0d45be70873e0ecaf350cc14e1cfForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store377c0d45be70873e0ecaf350cc14e1cf.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/admin/categories'
+ */
+        store377c0d45be70873e0ecaf350cc14e1cfForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store377c0d45be70873e0ecaf350cc14e1cf.url(options),
+            method: 'post',
+        })
+    
+    store377c0d45be70873e0ecaf350cc14e1cf.form = store377c0d45be70873e0ecaf350cc14e1cfForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/kaprodi/admin/categories'
+ */
+const store8b07aa3b1c2796b83a14462ab0656d15 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store8b07aa3b1c2796b83a14462ab0656d15.url(options),
+    method: 'post',
+})
+
+store8b07aa3b1c2796b83a14462ab0656d15.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/categories',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/kaprodi/admin/categories'
+ */
+store8b07aa3b1c2796b83a14462ab0656d15.url = (options?: RouteQueryOptions) => {
+    return store8b07aa3b1c2796b83a14462ab0656d15.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/kaprodi/admin/categories'
+ */
+store8b07aa3b1c2796b83a14462ab0656d15.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store8b07aa3b1c2796b83a14462ab0656d15.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/kaprodi/admin/categories'
+ */
+    const store8b07aa3b1c2796b83a14462ab0656d15Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store8b07aa3b1c2796b83a14462ab0656d15.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/kaprodi/admin/categories'
+ */
+        store8b07aa3b1c2796b83a14462ab0656d15Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store8b07aa3b1c2796b83a14462ab0656d15.url(options),
+            method: 'post',
+        })
+    
+    store8b07aa3b1c2796b83a14462ab0656d15.form = store8b07aa3b1c2796b83a14462ab0656d15Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/dekan/admin/categories'
+ */
+const storeab103ac7bafaf67a1bab6c43d4f96ad8 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: storeab103ac7bafaf67a1bab6c43d4f96ad8.url(options),
+    method: 'post',
+})
+
+storeab103ac7bafaf67a1bab6c43d4f96ad8.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/categories',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/dekan/admin/categories'
+ */
+storeab103ac7bafaf67a1bab6c43d4f96ad8.url = (options?: RouteQueryOptions) => {
+    return storeab103ac7bafaf67a1bab6c43d4f96ad8.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/dekan/admin/categories'
+ */
+storeab103ac7bafaf67a1bab6c43d4f96ad8.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: storeab103ac7bafaf67a1bab6c43d4f96ad8.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/dekan/admin/categories'
+ */
+    const storeab103ac7bafaf67a1bab6c43d4f96ad8Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: storeab103ac7bafaf67a1bab6c43d4f96ad8.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::store
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:25
+ * @route '/dekan/admin/categories'
+ */
+        storeab103ac7bafaf67a1bab6c43d4f96ad8Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: storeab103ac7bafaf67a1bab6c43d4f96ad8.url(options),
+            method: 'post',
+        })
+    
+    storeab103ac7bafaf67a1bab6c43d4f96ad8.form = storeab103ac7bafaf67a1bab6c43d4f96ad8Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\CategoryController::store, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `store['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const store = {
+    '/admin/categories': store377c0d45be70873e0ecaf350cc14e1cf,
+    '/kaprodi/admin/categories': store8b07aa3b1c2796b83a14462ab0656d15,
+    '/dekan/admin/categories': storeab103ac7bafaf67a1bab6c43d4f96ad8,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:40
-* @route '/admin/categories/{category}'
-*/
-export const update = (args: { category: string | number | { id: string | number } } | [category: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
-    url: update.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/admin/categories/{category}'
+ */
+const updated3574d41649b4dd208d031db42e0efd4 = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: updated3574d41649b4dd208d031db42e0efd4.url(args, options),
     method: 'put',
 })
 
-update.definition = {
+updated3574d41649b4dd208d031db42e0efd4.definition = {
     methods: ["put"],
     url: '/admin/categories/{category}',
 } satisfies RouteDefinition<["put"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:40
-* @route '/admin/categories/{category}'
-*/
-update.url = (args: { category: string | number | { id: string | number } } | [category: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/admin/categories/{category}'
+ */
+updated3574d41649b4dd208d031db42e0efd4.url = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { category: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { category: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { category: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            category: args[0],
-        }
+                    category: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        category: typeof args.category === 'object'
-        ? args.category.id
-        : args.category,
-    }
+                        category: typeof args.category === 'object'
+                ? args.category.id
+                : args.category,
+                }
 
-    return update.definition.url
+    return updated3574d41649b4dd208d031db42e0efd4.definition.url
             .replace('{category}', parsedArgs.category.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:40
-* @route '/admin/categories/{category}'
-*/
-update.put = (args: { category: string | number | { id: string | number } } | [category: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
-    url: update.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/admin/categories/{category}'
+ */
+updated3574d41649b4dd208d031db42e0efd4.put = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: updated3574d41649b4dd208d031db42e0efd4.url(args, options),
     method: 'put',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/admin/categories/{category}'
+ */
+    const updated3574d41649b4dd208d031db42e0efd4Form = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: updated3574d41649b4dd208d031db42e0efd4.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/admin/categories/{category}'
+ */
+        updated3574d41649b4dd208d031db42e0efd4Form.put = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: updated3574d41649b4dd208d031db42e0efd4.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    updated3574d41649b4dd208d031db42e0efd4.form = updated3574d41649b4dd208d031db42e0efd4Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+const update017c645f2893a21c57fb24ddf26dbd68 = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update017c645f2893a21c57fb24ddf26dbd68.url(args, options),
+    method: 'put',
+})
+
+update017c645f2893a21c57fb24ddf26dbd68.definition = {
+    methods: ["put"],
+    url: '/kaprodi/admin/categories/{category}',
+} satisfies RouteDefinition<["put"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+update017c645f2893a21c57fb24ddf26dbd68.url = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { category: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { category: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    category: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        category: typeof args.category === 'object'
+                ? args.category.id
+                : args.category,
+                }
+
+    return update017c645f2893a21c57fb24ddf26dbd68.definition.url
+            .replace('{category}', parsedArgs.category.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+update017c645f2893a21c57fb24ddf26dbd68.put = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update017c645f2893a21c57fb24ddf26dbd68.url(args, options),
+    method: 'put',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+    const update017c645f2893a21c57fb24ddf26dbd68Form = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update017c645f2893a21c57fb24ddf26dbd68.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+        update017c645f2893a21c57fb24ddf26dbd68Form.put = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update017c645f2893a21c57fb24ddf26dbd68.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update017c645f2893a21c57fb24ddf26dbd68.form = update017c645f2893a21c57fb24ddf26dbd68Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/dekan/admin/categories/{category}'
+ */
+const update77b15b03af456df615b1604b47e0af3b = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update77b15b03af456df615b1604b47e0af3b.url(args, options),
+    method: 'put',
+})
+
+update77b15b03af456df615b1604b47e0af3b.definition = {
+    methods: ["put"],
+    url: '/dekan/admin/categories/{category}',
+} satisfies RouteDefinition<["put"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/dekan/admin/categories/{category}'
+ */
+update77b15b03af456df615b1604b47e0af3b.url = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { category: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { category: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    category: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        category: typeof args.category === 'object'
+                ? args.category.id
+                : args.category,
+                }
+
+    return update77b15b03af456df615b1604b47e0af3b.definition.url
+            .replace('{category}', parsedArgs.category.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/dekan/admin/categories/{category}'
+ */
+update77b15b03af456df615b1604b47e0af3b.put = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update77b15b03af456df615b1604b47e0af3b.url(args, options),
+    method: 'put',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/dekan/admin/categories/{category}'
+ */
+    const update77b15b03af456df615b1604b47e0af3bForm = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update77b15b03af456df615b1604b47e0af3b.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::update
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:43
+ * @route '/dekan/admin/categories/{category}'
+ */
+        update77b15b03af456df615b1604b47e0af3bForm.put = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update77b15b03af456df615b1604b47e0af3b.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update77b15b03af456df615b1604b47e0af3b.form = update77b15b03af456df615b1604b47e0af3bForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\CategoryController::update, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `update['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const update = {
+    '/admin/categories/{category}': updated3574d41649b4dd208d031db42e0efd4,
+    '/kaprodi/admin/categories/{category}': update017c645f2893a21c57fb24ddf26dbd68,
+    '/dekan/admin/categories/{category}': update77b15b03af456df615b1604b47e0af3b,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:56
-* @route '/admin/categories/{category}'
-*/
-export const destroy = (args: { category: string | number | { id: string | number } } | [category: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
-    url: destroy.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/admin/categories/{category}'
+ */
+const destroyd3574d41649b4dd208d031db42e0efd4 = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroyd3574d41649b4dd208d031db42e0efd4.url(args, options),
     method: 'delete',
 })
 
-destroy.definition = {
+destroyd3574d41649b4dd208d031db42e0efd4.definition = {
     methods: ["delete"],
     url: '/admin/categories/{category}',
 } satisfies RouteDefinition<["delete"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:56
-* @route '/admin/categories/{category}'
-*/
-destroy.url = (args: { category: string | number | { id: string | number } } | [category: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/admin/categories/{category}'
+ */
+destroyd3574d41649b4dd208d031db42e0efd4.url = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { category: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { category: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { category: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            category: args[0],
-        }
+                    category: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        category: typeof args.category === 'object'
-        ? args.category.id
-        : args.category,
-    }
+                        category: typeof args.category === 'object'
+                ? args.category.id
+                : args.category,
+                }
 
-    return destroy.definition.url
+    return destroyd3574d41649b4dd208d031db42e0efd4.definition.url
             .replace('{category}', parsedArgs.category.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
-* @see app/Modules/Fast/Controllers/Admin/CategoryController.php:56
-* @route '/admin/categories/{category}'
-*/
-destroy.delete = (args: { category: string | number | { id: string | number } } | [category: string | number | { id: string | number } ] | string | number | { id: string | number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
-    url: destroy.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/admin/categories/{category}'
+ */
+destroyd3574d41649b4dd208d031db42e0efd4.delete = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroyd3574d41649b4dd208d031db42e0efd4.url(args, options),
     method: 'delete',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/admin/categories/{category}'
+ */
+    const destroyd3574d41649b4dd208d031db42e0efd4Form = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroyd3574d41649b4dd208d031db42e0efd4.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/admin/categories/{category}'
+ */
+        destroyd3574d41649b4dd208d031db42e0efd4Form.delete = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroyd3574d41649b4dd208d031db42e0efd4.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroyd3574d41649b4dd208d031db42e0efd4.form = destroyd3574d41649b4dd208d031db42e0efd4Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+const destroy017c645f2893a21c57fb24ddf26dbd68 = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy017c645f2893a21c57fb24ddf26dbd68.url(args, options),
+    method: 'delete',
+})
+
+destroy017c645f2893a21c57fb24ddf26dbd68.definition = {
+    methods: ["delete"],
+    url: '/kaprodi/admin/categories/{category}',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+destroy017c645f2893a21c57fb24ddf26dbd68.url = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { category: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { category: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    category: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        category: typeof args.category === 'object'
+                ? args.category.id
+                : args.category,
+                }
+
+    return destroy017c645f2893a21c57fb24ddf26dbd68.definition.url
+            .replace('{category}', parsedArgs.category.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+destroy017c645f2893a21c57fb24ddf26dbd68.delete = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy017c645f2893a21c57fb24ddf26dbd68.url(args, options),
+    method: 'delete',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+    const destroy017c645f2893a21c57fb24ddf26dbd68Form = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroy017c645f2893a21c57fb24ddf26dbd68.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/kaprodi/admin/categories/{category}'
+ */
+        destroy017c645f2893a21c57fb24ddf26dbd68Form.delete = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroy017c645f2893a21c57fb24ddf26dbd68.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroy017c645f2893a21c57fb24ddf26dbd68.form = destroy017c645f2893a21c57fb24ddf26dbd68Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/dekan/admin/categories/{category}'
+ */
+const destroy77b15b03af456df615b1604b47e0af3b = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy77b15b03af456df615b1604b47e0af3b.url(args, options),
+    method: 'delete',
+})
+
+destroy77b15b03af456df615b1604b47e0af3b.definition = {
+    methods: ["delete"],
+    url: '/dekan/admin/categories/{category}',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/dekan/admin/categories/{category}'
+ */
+destroy77b15b03af456df615b1604b47e0af3b.url = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { category: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { category: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    category: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        category: typeof args.category === 'object'
+                ? args.category.id
+                : args.category,
+                }
+
+    return destroy77b15b03af456df615b1604b47e0af3b.definition.url
+            .replace('{category}', parsedArgs.category.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/dekan/admin/categories/{category}'
+ */
+destroy77b15b03af456df615b1604b47e0af3b.delete = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy77b15b03af456df615b1604b47e0af3b.url(args, options),
+    method: 'delete',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/dekan/admin/categories/{category}'
+ */
+    const destroy77b15b03af456df615b1604b47e0af3bForm = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroy77b15b03af456df615b1604b47e0af3b.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\CategoryController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/CategoryController.php:60
+ * @route '/dekan/admin/categories/{category}'
+ */
+        destroy77b15b03af456df615b1604b47e0af3bForm.delete = (args: { category: number | { id: number } } | [category: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroy77b15b03af456df615b1604b47e0af3b.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroy77b15b03af456df615b1604b47e0af3b.form = destroy77b15b03af456df615b1604b47e0af3bForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\CategoryController::destroy, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `destroy['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const destroy = {
+    '/admin/categories/{category}': destroyd3574d41649b4dd208d031db42e0efd4,
+    '/kaprodi/admin/categories/{category}': destroy017c645f2893a21c57fb24ddf26dbd68,
+    '/dekan/admin/categories/{category}': destroy77b15b03af456df615b1604b47e0af3b,
+}
 
 const CategoryController = { index, store, update, destroy }
 

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/DashboardController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/DashboardController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/documents/public/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/public/surat/{id}/template-preview'
+ */
 const previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.url(args, options),
     method: 'get',
@@ -16,25 +16,26 @@ previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/documents/public/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/public/surat/{id}/template-preview'
+ */
 previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -43,29 +44,63 @@ previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.url = (args: { id: string | numb
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/documents/public/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/public/surat/{id}/template-preview'
+ */
 previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/documents/public/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/public/surat/{id}/template-preview'
+ */
 previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.url(args, options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/documents/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/public/surat/{id}/template-preview'
+ */
+    const previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/public/surat/{id}/template-preview'
+ */
+        previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/public/surat/{id}/template-preview'
+ */
+        previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8.form = previewTemplate186871ff0b5e0c1f1e7a1072b8450ee8Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/surat/{id}/template-preview'
+ */
 const previewTemplateee614e014c85387e34677786d92b7354 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewTemplateee614e014c85387e34677786d92b7354.url(args, options),
     method: 'get',
@@ -78,25 +113,26 @@ previewTemplateee614e014c85387e34677786d92b7354.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/documents/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/surat/{id}/template-preview'
+ */
 previewTemplateee614e014c85387e34677786d92b7354.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewTemplateee614e014c85387e34677786d92b7354.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -105,29 +141,63 @@ previewTemplateee614e014c85387e34677786d92b7354.url = (args: { id: string | numb
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/documents/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/surat/{id}/template-preview'
+ */
 previewTemplateee614e014c85387e34677786d92b7354.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewTemplateee614e014c85387e34677786d92b7354.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/documents/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/surat/{id}/template-preview'
+ */
 previewTemplateee614e014c85387e34677786d92b7354.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewTemplateee614e014c85387e34677786d92b7354.url(args, options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/admin/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/surat/{id}/template-preview'
+ */
+    const previewTemplateee614e014c85387e34677786d92b7354Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewTemplateee614e014c85387e34677786d92b7354.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/surat/{id}/template-preview'
+ */
+        previewTemplateee614e014c85387e34677786d92b7354Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewTemplateee614e014c85387e34677786d92b7354.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/documents/surat/{id}/template-preview'
+ */
+        previewTemplateee614e014c85387e34677786d92b7354Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewTemplateee614e014c85387e34677786d92b7354.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewTemplateee614e014c85387e34677786d92b7354.form = previewTemplateee614e014c85387e34677786d92b7354Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/admin/surat/{id}/template-preview'
+ */
 const previewTemplate5ca38ce12df99acea33c48ceb303e37d = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewTemplate5ca38ce12df99acea33c48ceb303e37d.url(args, options),
     method: 'get',
@@ -140,25 +210,26 @@ previewTemplate5ca38ce12df99acea33c48ceb303e37d.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/admin/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/admin/surat/{id}/template-preview'
+ */
 previewTemplate5ca38ce12df99acea33c48ceb303e37d.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewTemplate5ca38ce12df99acea33c48ceb303e37d.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -167,23 +238,58 @@ previewTemplate5ca38ce12df99acea33c48ceb303e37d.url = (args: { id: string | numb
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/admin/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/admin/surat/{id}/template-preview'
+ */
 previewTemplate5ca38ce12df99acea33c48ceb303e37d.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewTemplate5ca38ce12df99acea33c48ceb303e37d.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:31
-* @route '/admin/surat/{id}/template-preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/admin/surat/{id}/template-preview'
+ */
 previewTemplate5ca38ce12df99acea33c48ceb303e37d.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewTemplate5ca38ce12df99acea33c48ceb303e37d.url(args, options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/admin/surat/{id}/template-preview'
+ */
+    const previewTemplate5ca38ce12df99acea33c48ceb303e37dForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewTemplate5ca38ce12df99acea33c48ceb303e37d.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/admin/surat/{id}/template-preview'
+ */
+        previewTemplate5ca38ce12df99acea33c48ceb303e37dForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewTemplate5ca38ce12df99acea33c48ceb303e37d.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:38
+ * @route '/admin/surat/{id}/template-preview'
+ */
+        previewTemplate5ca38ce12df99acea33c48ceb303e37dForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewTemplate5ca38ce12df99acea33c48ceb303e37d.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewTemplate5ca38ce12df99acea33c48ceb303e37d.form = previewTemplate5ca38ce12df99acea33c48ceb303e37dForm
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::previewTemplate, so this export is a
@@ -198,9 +304,9 @@ export const previewTemplate = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/documents/public/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/public/surat/{id}/generated-document'
+ */
 const previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.url(args, options),
     method: 'get',
@@ -213,25 +319,26 @@ previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/documents/public/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/public/surat/{id}/generated-document'
+ */
 previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -240,29 +347,63 @@ previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.url = (args: { id: stri
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/documents/public/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/public/surat/{id}/generated-document'
+ */
 previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/documents/public/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/public/surat/{id}/generated-document'
+ */
 previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.url(args, options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/documents/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/public/surat/{id}/generated-document'
+ */
+    const previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6aForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/public/surat/{id}/generated-document'
+ */
+        previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6aForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/public/surat/{id}/generated-document'
+ */
+        previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6aForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6a.form = previewGeneratedDocumenteaeb27015f65a96b31d9ec0f00acbb6aForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/surat/{id}/generated-document'
+ */
 const previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.url(args, options),
     method: 'get',
@@ -275,25 +416,26 @@ previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/documents/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/surat/{id}/generated-document'
+ */
 previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -302,29 +444,63 @@ previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.url = (args: { id: stri
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/documents/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/surat/{id}/generated-document'
+ */
 previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/documents/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/surat/{id}/generated-document'
+ */
 previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.url(args, options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/admin/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/surat/{id}/generated-document'
+ */
+    const previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/surat/{id}/generated-document'
+ */
+        previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/documents/surat/{id}/generated-document'
+ */
+        previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067.form = previewGeneratedDocument35d5c331c7d7f999cb47e33c0877e067Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/admin/surat/{id}/generated-document'
+ */
 const previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.url(args, options),
     method: 'get',
@@ -337,25 +513,26 @@ previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/admin/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/admin/surat/{id}/generated-document'
+ */
 previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -364,23 +541,58 @@ previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.url = (args: { id: stri
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/admin/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/admin/surat/{id}/generated-document'
+ */
 previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:36
-* @route '/admin/surat/{id}/generated-document'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/admin/surat/{id}/generated-document'
+ */
 previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.url(args, options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/admin/surat/{id}/generated-document'
+ */
+    const previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/admin/surat/{id}/generated-document'
+ */
+        previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
+ * @route '/admin/surat/{id}/generated-document'
+ */
+        previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462.form = previewGeneratedDocumentece765c81e171029b99b1ecd76d2d462Form
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::previewGeneratedDocument, so this export is a
@@ -395,9 +607,9 @@ export const previewGeneratedDocument = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/documents/public/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/public/surat/{id}/pdf'
+ */
 const downloadPdf175f3b2747492debcba34c78c9a49c61 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: downloadPdf175f3b2747492debcba34c78c9a49c61.url(args, options),
     method: 'get',
@@ -410,25 +622,26 @@ downloadPdf175f3b2747492debcba34c78c9a49c61.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/documents/public/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/public/surat/{id}/pdf'
+ */
 downloadPdf175f3b2747492debcba34c78c9a49c61.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return downloadPdf175f3b2747492debcba34c78c9a49c61.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -437,29 +650,63 @@ downloadPdf175f3b2747492debcba34c78c9a49c61.url = (args: { id: string | number }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/documents/public/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/public/surat/{id}/pdf'
+ */
 downloadPdf175f3b2747492debcba34c78c9a49c61.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: downloadPdf175f3b2747492debcba34c78c9a49c61.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/documents/public/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/public/surat/{id}/pdf'
+ */
 downloadPdf175f3b2747492debcba34c78c9a49c61.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: downloadPdf175f3b2747492debcba34c78c9a49c61.url(args, options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/documents/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/public/surat/{id}/pdf'
+ */
+    const downloadPdf175f3b2747492debcba34c78c9a49c61Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: downloadPdf175f3b2747492debcba34c78c9a49c61.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/public/surat/{id}/pdf'
+ */
+        downloadPdf175f3b2747492debcba34c78c9a49c61Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadPdf175f3b2747492debcba34c78c9a49c61.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/public/surat/{id}/pdf'
+ */
+        downloadPdf175f3b2747492debcba34c78c9a49c61Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadPdf175f3b2747492debcba34c78c9a49c61.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    downloadPdf175f3b2747492debcba34c78c9a49c61.form = downloadPdf175f3b2747492debcba34c78c9a49c61Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/surat/{id}/pdf'
+ */
 const downloadPdfccfc3e9865ca14301019c9d23437884e = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: downloadPdfccfc3e9865ca14301019c9d23437884e.url(args, options),
     method: 'get',
@@ -472,25 +719,26 @@ downloadPdfccfc3e9865ca14301019c9d23437884e.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/documents/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/surat/{id}/pdf'
+ */
 downloadPdfccfc3e9865ca14301019c9d23437884e.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return downloadPdfccfc3e9865ca14301019c9d23437884e.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -499,29 +747,63 @@ downloadPdfccfc3e9865ca14301019c9d23437884e.url = (args: { id: string | number }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/documents/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/surat/{id}/pdf'
+ */
 downloadPdfccfc3e9865ca14301019c9d23437884e.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: downloadPdfccfc3e9865ca14301019c9d23437884e.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/documents/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/surat/{id}/pdf'
+ */
 downloadPdfccfc3e9865ca14301019c9d23437884e.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: downloadPdfccfc3e9865ca14301019c9d23437884e.url(args, options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/admin/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/surat/{id}/pdf'
+ */
+    const downloadPdfccfc3e9865ca14301019c9d23437884eForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: downloadPdfccfc3e9865ca14301019c9d23437884e.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/surat/{id}/pdf'
+ */
+        downloadPdfccfc3e9865ca14301019c9d23437884eForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadPdfccfc3e9865ca14301019c9d23437884e.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/documents/surat/{id}/pdf'
+ */
+        downloadPdfccfc3e9865ca14301019c9d23437884eForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadPdfccfc3e9865ca14301019c9d23437884e.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    downloadPdfccfc3e9865ca14301019c9d23437884e.form = downloadPdfccfc3e9865ca14301019c9d23437884eForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/admin/surat/{id}/pdf'
+ */
 const downloadPdf05d105208d0811647b427cb9e4a2a116 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: downloadPdf05d105208d0811647b427cb9e4a2a116.url(args, options),
     method: 'get',
@@ -534,25 +816,26 @@ downloadPdf05d105208d0811647b427cb9e4a2a116.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/admin/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/admin/surat/{id}/pdf'
+ */
 downloadPdf05d105208d0811647b427cb9e4a2a116.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return downloadPdf05d105208d0811647b427cb9e4a2a116.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -561,23 +844,58 @@ downloadPdf05d105208d0811647b427cb9e4a2a116.url = (args: { id: string | number }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/admin/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/admin/surat/{id}/pdf'
+ */
 downloadPdf05d105208d0811647b427cb9e4a2a116.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: downloadPdf05d105208d0811647b427cb9e4a2a116.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:41
-* @route '/admin/surat/{id}/pdf'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/admin/surat/{id}/pdf'
+ */
 downloadPdf05d105208d0811647b427cb9e4a2a116.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: downloadPdf05d105208d0811647b427cb9e4a2a116.url(args, options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/admin/surat/{id}/pdf'
+ */
+    const downloadPdf05d105208d0811647b427cb9e4a2a116Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: downloadPdf05d105208d0811647b427cb9e4a2a116.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/admin/surat/{id}/pdf'
+ */
+        downloadPdf05d105208d0811647b427cb9e4a2a116Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadPdf05d105208d0811647b427cb9e4a2a116.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:54
+ * @route '/admin/surat/{id}/pdf'
+ */
+        downloadPdf05d105208d0811647b427cb9e4a2a116Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadPdf05d105208d0811647b427cb9e4a2a116.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    downloadPdf05d105208d0811647b427cb9e4a2a116.form = downloadPdf05d105208d0811647b427cb9e4a2a116Form
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::downloadPdf, so this export is a
@@ -591,10 +909,713 @@ export const downloadPdf = {
 }
 
 /**
-* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
-* @route '/documents/lampiran/{id}/preview'
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/public/surat/{id}/attachment-document'
+ */
+const previewAttachmentDocument8720acd5cf3955db442eddf519381d1b = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.url(args, options),
+    method: 'get',
+})
+
+previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.definition = {
+    methods: ["get","head"],
+    url: '/documents/public/surat/{id}/attachment-document',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/public/surat/{id}/attachment-document'
+ */
+previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/public/surat/{id}/attachment-document'
+ */
+previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/public/surat/{id}/attachment-document'
+ */
+previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/public/surat/{id}/attachment-document'
+ */
+    const previewAttachmentDocument8720acd5cf3955db442eddf519381d1bForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/public/surat/{id}/attachment-document'
+ */
+        previewAttachmentDocument8720acd5cf3955db442eddf519381d1bForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/public/surat/{id}/attachment-document'
+ */
+        previewAttachmentDocument8720acd5cf3955db442eddf519381d1bForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewAttachmentDocument8720acd5cf3955db442eddf519381d1b.form = previewAttachmentDocument8720acd5cf3955db442eddf519381d1bForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/surat/{id}/attachment-document'
+ */
+const previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.url(args, options),
+    method: 'get',
+})
+
+previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.definition = {
+    methods: ["get","head"],
+    url: '/documents/surat/{id}/attachment-document',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/surat/{id}/attachment-document'
+ */
+previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/surat/{id}/attachment-document'
+ */
+previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/surat/{id}/attachment-document'
+ */
+previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/surat/{id}/attachment-document'
+ */
+    const previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2aForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/surat/{id}/attachment-document'
+ */
+        previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2aForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/documents/surat/{id}/attachment-document'
+ */
+        previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2aForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a.form = previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2aForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/admin/surat/{id}/attachment-document'
+ */
+const previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.url(args, options),
+    method: 'get',
+})
+
+previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.definition = {
+    methods: ["get","head"],
+    url: '/admin/surat/{id}/attachment-document',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/admin/surat/{id}/attachment-document'
+ */
+previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/admin/surat/{id}/attachment-document'
+ */
+previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/admin/surat/{id}/attachment-document'
+ */
+previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/admin/surat/{id}/attachment-document'
+ */
+    const previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2cForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/admin/surat/{id}/attachment-document'
+ */
+        previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2cForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:62
+ * @route '/admin/surat/{id}/attachment-document'
+ */
+        previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2cForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c.form = previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2cForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachmentDocument, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `previewAttachmentDocument['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
 */
+export const previewAttachmentDocument = {
+    '/documents/public/surat/{id}/attachment-document': previewAttachmentDocument8720acd5cf3955db442eddf519381d1b,
+    '/documents/surat/{id}/attachment-document': previewAttachmentDocumentd17613bad81eb08556aea16b946b7e2a,
+    '/admin/surat/{id}/attachment-document': previewAttachmentDocumenta84193a3506562ba99b5902c740f9a2c,
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/public/surat/{id}/attachment-pdf'
+ */
+const downloadAttachmentPdf152584be3f1c5011949d323881a2bbee = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.url(args, options),
+    method: 'get',
+})
+
+downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.definition = {
+    methods: ["get","head"],
+    url: '/documents/public/surat/{id}/attachment-pdf',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/public/surat/{id}/attachment-pdf'
+ */
+downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/public/surat/{id}/attachment-pdf'
+ */
+downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/public/surat/{id}/attachment-pdf'
+ */
+downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/public/surat/{id}/attachment-pdf'
+ */
+    const downloadAttachmentPdf152584be3f1c5011949d323881a2bbeeForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/public/surat/{id}/attachment-pdf'
+ */
+        downloadAttachmentPdf152584be3f1c5011949d323881a2bbeeForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/public/surat/{id}/attachment-pdf'
+ */
+        downloadAttachmentPdf152584be3f1c5011949d323881a2bbeeForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    downloadAttachmentPdf152584be3f1c5011949d323881a2bbee.form = downloadAttachmentPdf152584be3f1c5011949d323881a2bbeeForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/surat/{id}/attachment-pdf'
+ */
+const downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.url(args, options),
+    method: 'get',
+})
+
+downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.definition = {
+    methods: ["get","head"],
+    url: '/documents/surat/{id}/attachment-pdf',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/surat/{id}/attachment-pdf'
+ */
+downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/surat/{id}/attachment-pdf'
+ */
+downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/surat/{id}/attachment-pdf'
+ */
+downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/surat/{id}/attachment-pdf'
+ */
+    const downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/surat/{id}/attachment-pdf'
+ */
+        downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/documents/surat/{id}/attachment-pdf'
+ */
+        downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9.form = downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/admin/surat/{id}/attachment-pdf'
+ */
+const downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.url(args, options),
+    method: 'get',
+})
+
+downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.definition = {
+    methods: ["get","head"],
+    url: '/admin/surat/{id}/attachment-pdf',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/admin/surat/{id}/attachment-pdf'
+ */
+downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/admin/surat/{id}/attachment-pdf'
+ */
+downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/admin/surat/{id}/attachment-pdf'
+ */
+downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/admin/surat/{id}/attachment-pdf'
+ */
+    const downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/admin/surat/{id}/attachment-pdf'
+ */
+        downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:70
+ * @route '/admin/surat/{id}/attachment-pdf'
+ */
+        downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9.form = downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::downloadAttachmentPdf, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `downloadAttachmentPdf['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const downloadAttachmentPdf = {
+    '/documents/public/surat/{id}/attachment-pdf': downloadAttachmentPdf152584be3f1c5011949d323881a2bbee,
+    '/documents/surat/{id}/attachment-pdf': downloadAttachmentPdf68ce1b85ebc195cfeadefdc3dd3cefa9,
+    '/admin/surat/{id}/attachment-pdf': downloadAttachmentPdfd1c3972bf199fae0d433df3c03bae5c9,
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/public/lampiran/{id}/preview'
+ */
+const previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.url(args, options),
+    method: 'get',
+})
+
+previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.definition = {
+    methods: ["get","head"],
+    url: '/documents/public/lampiran/{id}/preview',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/public/lampiran/{id}/preview'
+ */
+previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/public/lampiran/{id}/preview'
+ */
+previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/public/lampiran/{id}/preview'
+ */
+previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/public/lampiran/{id}/preview'
+ */
+    const previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/public/lampiran/{id}/preview'
+ */
+        previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/public/lampiran/{id}/preview'
+ */
+        previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0.form = previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/lampiran/{id}/preview'
+ */
 const previewAttachment4e6e297488f868d2b99e03f1750ec7db = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment4e6e297488f868d2b99e03f1750ec7db.url(args, options),
     method: 'get',
@@ -607,25 +1628,26 @@ previewAttachment4e6e297488f868d2b99e03f1750ec7db.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
-* @route '/documents/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/lampiran/{id}/preview'
+ */
 previewAttachment4e6e297488f868d2b99e03f1750ec7db.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewAttachment4e6e297488f868d2b99e03f1750ec7db.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -634,29 +1656,63 @@ previewAttachment4e6e297488f868d2b99e03f1750ec7db.url = (args: { id: string | nu
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
-* @route '/documents/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/lampiran/{id}/preview'
+ */
 previewAttachment4e6e297488f868d2b99e03f1750ec7db.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment4e6e297488f868d2b99e03f1750ec7db.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
-* @route '/documents/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/lampiran/{id}/preview'
+ */
 previewAttachment4e6e297488f868d2b99e03f1750ec7db.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewAttachment4e6e297488f868d2b99e03f1750ec7db.url(args, options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
-* @route '/admin/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/lampiran/{id}/preview'
+ */
+    const previewAttachment4e6e297488f868d2b99e03f1750ec7dbForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewAttachment4e6e297488f868d2b99e03f1750ec7db.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/lampiran/{id}/preview'
+ */
+        previewAttachment4e6e297488f868d2b99e03f1750ec7dbForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment4e6e297488f868d2b99e03f1750ec7db.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/documents/lampiran/{id}/preview'
+ */
+        previewAttachment4e6e297488f868d2b99e03f1750ec7dbForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment4e6e297488f868d2b99e03f1750ec7db.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewAttachment4e6e297488f868d2b99e03f1750ec7db.form = previewAttachment4e6e297488f868d2b99e03f1750ec7dbForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/admin/lampiran/{id}/preview'
+ */
 const previewAttachment475f6acc77985b523f13d9d85f732eed = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment475f6acc77985b523f13d9d85f732eed.url(args, options),
     method: 'get',
@@ -669,25 +1725,26 @@ previewAttachment475f6acc77985b523f13d9d85f732eed.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
-* @route '/admin/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/admin/lampiran/{id}/preview'
+ */
 previewAttachment475f6acc77985b523f13d9d85f732eed.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewAttachment475f6acc77985b523f13d9d85f732eed.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -696,23 +1753,58 @@ previewAttachment475f6acc77985b523f13d9d85f732eed.url = (args: { id: string | nu
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
-* @route '/admin/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/admin/lampiran/{id}/preview'
+ */
 previewAttachment475f6acc77985b523f13d9d85f732eed.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment475f6acc77985b523f13d9d85f732eed.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:46
-* @route '/admin/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/admin/lampiran/{id}/preview'
+ */
 previewAttachment475f6acc77985b523f13d9d85f732eed.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewAttachment475f6acc77985b523f13d9d85f732eed.url(args, options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/admin/lampiran/{id}/preview'
+ */
+    const previewAttachment475f6acc77985b523f13d9d85f732eedForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewAttachment475f6acc77985b523f13d9d85f732eed.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/admin/lampiran/{id}/preview'
+ */
+        previewAttachment475f6acc77985b523f13d9d85f732eedForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment475f6acc77985b523f13d9d85f732eed.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:78
+ * @route '/admin/lampiran/{id}/preview'
+ */
+        previewAttachment475f6acc77985b523f13d9d85f732eedForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment475f6acc77985b523f13d9d85f732eed.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewAttachment475f6acc77985b523f13d9d85f732eed.form = previewAttachment475f6acc77985b523f13d9d85f732eedForm
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::previewAttachment, so this export is a
@@ -720,282 +1812,1508 @@ previewAttachment475f6acc77985b523f13d9d85f732eed.head = (args: { id: string | n
 * or import the route by name from your generated `routes/` directory.
 */
 export const previewAttachment = {
+    '/documents/public/lampiran/{id}/preview': previewAttachment3f4b1de5bd279db0bbc497d4aca5dea0,
     '/documents/lampiran/{id}/preview': previewAttachment4e6e297488f868d2b99e03f1750ec7db,
     '/admin/lampiran/{id}/preview': previewAttachment475f6acc77985b523f13d9d85f732eed,
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:21
-* @route '/admin/dashboard'
-*/
-export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/admin/dashboard'
+ */
+const index750aeb224105761400ee952169bd178c = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index750aeb224105761400ee952169bd178c.url(options),
     method: 'get',
 })
 
-index.definition = {
+index750aeb224105761400ee952169bd178c.definition = {
     methods: ["get","head"],
     url: '/admin/dashboard',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:21
-* @route '/admin/dashboard'
-*/
-index.url = (options?: RouteQueryOptions) => {
-    return index.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/admin/dashboard'
+ */
+index750aeb224105761400ee952169bd178c.url = (options?: RouteQueryOptions) => {
+    return index750aeb224105761400ee952169bd178c.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:21
-* @route '/admin/dashboard'
-*/
-index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/admin/dashboard'
+ */
+index750aeb224105761400ee952169bd178c.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index750aeb224105761400ee952169bd178c.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:21
-* @route '/admin/dashboard'
-*/
-index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/admin/dashboard'
+ */
+index750aeb224105761400ee952169bd178c.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index750aeb224105761400ee952169bd178c.url(options),
     method: 'head',
 })
 
-/**
-* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:26
-* @route '/admin/surat/{id}'
-*/
-export const show = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: show.url(args, options),
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/admin/dashboard'
+ */
+    const index750aeb224105761400ee952169bd178cForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index750aeb224105761400ee952169bd178c.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/admin/dashboard'
+ */
+        index750aeb224105761400ee952169bd178cForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index750aeb224105761400ee952169bd178c.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/admin/dashboard'
+ */
+        index750aeb224105761400ee952169bd178cForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index750aeb224105761400ee952169bd178c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index750aeb224105761400ee952169bd178c.form = index750aeb224105761400ee952169bd178cForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/kaprodi/admin/dashboard'
+ */
+const index602e4ed5841f056b73584b0a141bd50e = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index602e4ed5841f056b73584b0a141bd50e.url(options),
     method: 'get',
 })
 
-show.definition = {
+index602e4ed5841f056b73584b0a141bd50e.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/dashboard',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/kaprodi/admin/dashboard'
+ */
+index602e4ed5841f056b73584b0a141bd50e.url = (options?: RouteQueryOptions) => {
+    return index602e4ed5841f056b73584b0a141bd50e.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/kaprodi/admin/dashboard'
+ */
+index602e4ed5841f056b73584b0a141bd50e.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index602e4ed5841f056b73584b0a141bd50e.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/kaprodi/admin/dashboard'
+ */
+index602e4ed5841f056b73584b0a141bd50e.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index602e4ed5841f056b73584b0a141bd50e.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/kaprodi/admin/dashboard'
+ */
+    const index602e4ed5841f056b73584b0a141bd50eForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index602e4ed5841f056b73584b0a141bd50e.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/kaprodi/admin/dashboard'
+ */
+        index602e4ed5841f056b73584b0a141bd50eForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index602e4ed5841f056b73584b0a141bd50e.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/kaprodi/admin/dashboard'
+ */
+        index602e4ed5841f056b73584b0a141bd50eForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index602e4ed5841f056b73584b0a141bd50e.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index602e4ed5841f056b73584b0a141bd50e.form = index602e4ed5841f056b73584b0a141bd50eForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/dekan/admin/dashboard'
+ */
+const indexce69f561054a160c65713918ce2cca67 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexce69f561054a160c65713918ce2cca67.url(options),
+    method: 'get',
+})
+
+indexce69f561054a160c65713918ce2cca67.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/dashboard',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/dekan/admin/dashboard'
+ */
+indexce69f561054a160c65713918ce2cca67.url = (options?: RouteQueryOptions) => {
+    return indexce69f561054a160c65713918ce2cca67.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/dekan/admin/dashboard'
+ */
+indexce69f561054a160c65713918ce2cca67.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexce69f561054a160c65713918ce2cca67.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/dekan/admin/dashboard'
+ */
+indexce69f561054a160c65713918ce2cca67.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexce69f561054a160c65713918ce2cca67.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/dekan/admin/dashboard'
+ */
+    const indexce69f561054a160c65713918ce2cca67Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexce69f561054a160c65713918ce2cca67.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/dekan/admin/dashboard'
+ */
+        indexce69f561054a160c65713918ce2cca67Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexce69f561054a160c65713918ce2cca67.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:23
+ * @route '/dekan/admin/dashboard'
+ */
+        indexce69f561054a160c65713918ce2cca67Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexce69f561054a160c65713918ce2cca67.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexce69f561054a160c65713918ce2cca67.form = indexce69f561054a160c65713918ce2cca67Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::index, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `index['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const index = {
+    '/admin/dashboard': index750aeb224105761400ee952169bd178c,
+    '/kaprodi/admin/dashboard': index602e4ed5841f056b73584b0a141bd50e,
+    '/dekan/admin/dashboard': indexce69f561054a160c65713918ce2cca67,
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/admin/surat/{id}'
+ */
+const showcaa2593158145898f04ae0567d4630f4 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: showcaa2593158145898f04ae0567d4630f4.url(args, options),
+    method: 'get',
+})
+
+showcaa2593158145898f04ae0567d4630f4.definition = {
     methods: ["get","head"],
     url: '/admin/surat/{id}',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:26
-* @route '/admin/surat/{id}'
-*/
-show.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/admin/surat/{id}'
+ */
+showcaa2593158145898f04ae0567d4630f4.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
-    return show.definition.url
+    return showcaa2593158145898f04ae0567d4630f4.definition.url
             .replace('{id}', parsedArgs.id.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:26
-* @route '/admin/surat/{id}'
-*/
-show.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: show.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/admin/surat/{id}'
+ */
+showcaa2593158145898f04ae0567d4630f4.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: showcaa2593158145898f04ae0567d4630f4.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:26
-* @route '/admin/surat/{id}'
-*/
-show.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: show.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/admin/surat/{id}'
+ */
+showcaa2593158145898f04ae0567d4630f4.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: showcaa2593158145898f04ae0567d4630f4.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/admin/surat/{id}'
+ */
+    const showcaa2593158145898f04ae0567d4630f4Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: showcaa2593158145898f04ae0567d4630f4.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/admin/surat/{id}'
+ */
+        showcaa2593158145898f04ae0567d4630f4Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: showcaa2593158145898f04ae0567d4630f4.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/admin/surat/{id}'
+ */
+        showcaa2593158145898f04ae0567d4630f4Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: showcaa2593158145898f04ae0567d4630f4.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    showcaa2593158145898f04ae0567d4630f4.form = showcaa2593158145898f04ae0567d4630f4Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+const show927fcee68fb401f2468c1f9e0dccf577 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: show927fcee68fb401f2468c1f9e0dccf577.url(args, options),
+    method: 'get',
+})
+
+show927fcee68fb401f2468c1f9e0dccf577.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/surat/{id}',
+} satisfies RouteDefinition<["get","head"]>
+
 /**
-* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:51
-* @route '/admin/surat/{id}/approve'
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+show927fcee68fb401f2468c1f9e0dccf577.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return show927fcee68fb401f2468c1f9e0dccf577.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+show927fcee68fb401f2468c1f9e0dccf577.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: show927fcee68fb401f2468c1f9e0dccf577.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+show927fcee68fb401f2468c1f9e0dccf577.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: show927fcee68fb401f2468c1f9e0dccf577.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+    const show927fcee68fb401f2468c1f9e0dccf577Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show927fcee68fb401f2468c1f9e0dccf577.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+        show927fcee68fb401f2468c1f9e0dccf577Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show927fcee68fb401f2468c1f9e0dccf577.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+        show927fcee68fb401f2468c1f9e0dccf577Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show927fcee68fb401f2468c1f9e0dccf577.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show927fcee68fb401f2468c1f9e0dccf577.form = show927fcee68fb401f2468c1f9e0dccf577Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/dekan/admin/surat/{id}'
+ */
+const show02a2db8a6087a1edeb8a0ca8e2e42db2 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: show02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, options),
+    method: 'get',
+})
+
+show02a2db8a6087a1edeb8a0ca8e2e42db2.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/surat/{id}',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/dekan/admin/surat/{id}'
+ */
+show02a2db8a6087a1edeb8a0ca8e2e42db2.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return show02a2db8a6087a1edeb8a0ca8e2e42db2.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/dekan/admin/surat/{id}'
+ */
+show02a2db8a6087a1edeb8a0ca8e2e42db2.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: show02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/dekan/admin/surat/{id}'
+ */
+show02a2db8a6087a1edeb8a0ca8e2e42db2.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: show02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/dekan/admin/surat/{id}'
+ */
+    const show02a2db8a6087a1edeb8a0ca8e2e42db2Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/dekan/admin/surat/{id}'
+ */
+        show02a2db8a6087a1edeb8a0ca8e2e42db2Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::show
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:30
+ * @route '/dekan/admin/surat/{id}'
+ */
+        show02a2db8a6087a1edeb8a0ca8e2e42db2Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show02a2db8a6087a1edeb8a0ca8e2e42db2.form = show02a2db8a6087a1edeb8a0ca8e2e42db2Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::show, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `show['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
 */
-export const approve = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: approve.url(args, options),
+export const show = {
+    '/admin/surat/{id}': showcaa2593158145898f04ae0567d4630f4,
+    '/kaprodi/admin/surat/{id}': show927fcee68fb401f2468c1f9e0dccf577,
+    '/dekan/admin/surat/{id}': show02a2db8a6087a1edeb8a0ca8e2e42db2,
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/admin/surat/bulk-approve'
+ */
+const bulkApprove4fe116f770c127cd5071ac3a65269eb7 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove4fe116f770c127cd5071ac3a65269eb7.url(options),
     method: 'post',
 })
 
-approve.definition = {
+bulkApprove4fe116f770c127cd5071ac3a65269eb7.definition = {
+    methods: ["post"],
+    url: '/admin/surat/bulk-approve',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/admin/surat/bulk-approve'
+ */
+bulkApprove4fe116f770c127cd5071ac3a65269eb7.url = (options?: RouteQueryOptions) => {
+    return bulkApprove4fe116f770c127cd5071ac3a65269eb7.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/admin/surat/bulk-approve'
+ */
+bulkApprove4fe116f770c127cd5071ac3a65269eb7.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove4fe116f770c127cd5071ac3a65269eb7.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/admin/surat/bulk-approve'
+ */
+    const bulkApprove4fe116f770c127cd5071ac3a65269eb7Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: bulkApprove4fe116f770c127cd5071ac3a65269eb7.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/admin/surat/bulk-approve'
+ */
+        bulkApprove4fe116f770c127cd5071ac3a65269eb7Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: bulkApprove4fe116f770c127cd5071ac3a65269eb7.url(options),
+            method: 'post',
+        })
+    
+    bulkApprove4fe116f770c127cd5071ac3a65269eb7.form = bulkApprove4fe116f770c127cd5071ac3a65269eb7Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/kaprodi/admin/surat/bulk-approve'
+ */
+const bulkApprove3a753b74e15092dd611151160e02cd5e = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove3a753b74e15092dd611151160e02cd5e.url(options),
+    method: 'post',
+})
+
+bulkApprove3a753b74e15092dd611151160e02cd5e.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/surat/bulk-approve',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/kaprodi/admin/surat/bulk-approve'
+ */
+bulkApprove3a753b74e15092dd611151160e02cd5e.url = (options?: RouteQueryOptions) => {
+    return bulkApprove3a753b74e15092dd611151160e02cd5e.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/kaprodi/admin/surat/bulk-approve'
+ */
+bulkApprove3a753b74e15092dd611151160e02cd5e.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove3a753b74e15092dd611151160e02cd5e.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/kaprodi/admin/surat/bulk-approve'
+ */
+    const bulkApprove3a753b74e15092dd611151160e02cd5eForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: bulkApprove3a753b74e15092dd611151160e02cd5e.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/kaprodi/admin/surat/bulk-approve'
+ */
+        bulkApprove3a753b74e15092dd611151160e02cd5eForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: bulkApprove3a753b74e15092dd611151160e02cd5e.url(options),
+            method: 'post',
+        })
+    
+    bulkApprove3a753b74e15092dd611151160e02cd5e.form = bulkApprove3a753b74e15092dd611151160e02cd5eForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/dekan/admin/surat/bulk-approve'
+ */
+const bulkApprove2662aba274dd3cfaf3c340df0106029f = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove2662aba274dd3cfaf3c340df0106029f.url(options),
+    method: 'post',
+})
+
+bulkApprove2662aba274dd3cfaf3c340df0106029f.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/surat/bulk-approve',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/dekan/admin/surat/bulk-approve'
+ */
+bulkApprove2662aba274dd3cfaf3c340df0106029f.url = (options?: RouteQueryOptions) => {
+    return bulkApprove2662aba274dd3cfaf3c340df0106029f.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/dekan/admin/surat/bulk-approve'
+ */
+bulkApprove2662aba274dd3cfaf3c340df0106029f.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove2662aba274dd3cfaf3c340df0106029f.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/dekan/admin/surat/bulk-approve'
+ */
+    const bulkApprove2662aba274dd3cfaf3c340df0106029fForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: bulkApprove2662aba274dd3cfaf3c340df0106029f.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:100
+ * @route '/dekan/admin/surat/bulk-approve'
+ */
+        bulkApprove2662aba274dd3cfaf3c340df0106029fForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: bulkApprove2662aba274dd3cfaf3c340df0106029f.url(options),
+            method: 'post',
+        })
+    
+    bulkApprove2662aba274dd3cfaf3c340df0106029f.form = bulkApprove2662aba274dd3cfaf3c340df0106029fForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::bulkApprove, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `bulkApprove['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const bulkApprove = {
+    '/admin/surat/bulk-approve': bulkApprove4fe116f770c127cd5071ac3a65269eb7,
+    '/kaprodi/admin/surat/bulk-approve': bulkApprove3a753b74e15092dd611151160e02cd5e,
+    '/dekan/admin/surat/bulk-approve': bulkApprove2662aba274dd3cfaf3c340df0106029f,
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/admin/surat/{id}/approve'
+ */
+const approve16eb56d0276f964abeb59572e2a001a2 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: approve16eb56d0276f964abeb59572e2a001a2.url(args, options),
+    method: 'post',
+})
+
+approve16eb56d0276f964abeb59572e2a001a2.definition = {
     methods: ["post"],
     url: '/admin/surat/{id}/approve',
 } satisfies RouteDefinition<["post"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:51
-* @route '/admin/surat/{id}/approve'
-*/
-approve.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/admin/surat/{id}/approve'
+ */
+approve16eb56d0276f964abeb59572e2a001a2.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
-    return approve.definition.url
+    return approve16eb56d0276f964abeb59572e2a001a2.definition.url
             .replace('{id}', parsedArgs.id.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:51
-* @route '/admin/surat/{id}/approve'
-*/
-approve.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: approve.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/admin/surat/{id}/approve'
+ */
+approve16eb56d0276f964abeb59572e2a001a2.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: approve16eb56d0276f964abeb59572e2a001a2.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/admin/surat/{id}/approve'
+ */
+    const approve16eb56d0276f964abeb59572e2a001a2Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: approve16eb56d0276f964abeb59572e2a001a2.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/admin/surat/{id}/approve'
+ */
+        approve16eb56d0276f964abeb59572e2a001a2Form.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: approve16eb56d0276f964abeb59572e2a001a2.url(args, options),
+            method: 'post',
+        })
+    
+    approve16eb56d0276f964abeb59572e2a001a2.form = approve16eb56d0276f964abeb59572e2a001a2Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/kaprodi/admin/surat/{id}/approve'
+ */
+const approve27ee588a20739839eef910dd2189e957 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: approve27ee588a20739839eef910dd2189e957.url(args, options),
+    method: 'post',
+})
+
+approve27ee588a20739839eef910dd2189e957.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/surat/{id}/approve',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/kaprodi/admin/surat/{id}/approve'
+ */
+approve27ee588a20739839eef910dd2189e957.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return approve27ee588a20739839eef910dd2189e957.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/kaprodi/admin/surat/{id}/approve'
+ */
+approve27ee588a20739839eef910dd2189e957.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: approve27ee588a20739839eef910dd2189e957.url(args, options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/kaprodi/admin/surat/{id}/approve'
+ */
+    const approve27ee588a20739839eef910dd2189e957Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: approve27ee588a20739839eef910dd2189e957.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/kaprodi/admin/surat/{id}/approve'
+ */
+        approve27ee588a20739839eef910dd2189e957Form.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: approve27ee588a20739839eef910dd2189e957.url(args, options),
+            method: 'post',
+        })
+    
+    approve27ee588a20739839eef910dd2189e957.form = approve27ee588a20739839eef910dd2189e957Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/dekan/admin/surat/{id}/approve'
+ */
+const approvea20e3116d12d2583e44b08defd89e10d = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: approvea20e3116d12d2583e44b08defd89e10d.url(args, options),
+    method: 'post',
+})
+
+approvea20e3116d12d2583e44b08defd89e10d.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/surat/{id}/approve',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/dekan/admin/surat/{id}/approve'
+ */
+approvea20e3116d12d2583e44b08defd89e10d.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return approvea20e3116d12d2583e44b08defd89e10d.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/dekan/admin/surat/{id}/approve'
+ */
+approvea20e3116d12d2583e44b08defd89e10d.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: approvea20e3116d12d2583e44b08defd89e10d.url(args, options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/dekan/admin/surat/{id}/approve'
+ */
+    const approvea20e3116d12d2583e44b08defd89e10dForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: approvea20e3116d12d2583e44b08defd89e10d.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::approve
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:92
+ * @route '/dekan/admin/surat/{id}/approve'
+ */
+        approvea20e3116d12d2583e44b08defd89e10dForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: approvea20e3116d12d2583e44b08defd89e10d.url(args, options),
+            method: 'post',
+        })
+    
+    approvea20e3116d12d2583e44b08defd89e10d.form = approvea20e3116d12d2583e44b08defd89e10dForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::approve, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `approve['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const approve = {
+    '/admin/surat/{id}/approve': approve16eb56d0276f964abeb59572e2a001a2,
+    '/kaprodi/admin/surat/{id}/approve': approve27ee588a20739839eef910dd2189e957,
+    '/dekan/admin/surat/{id}/approve': approvea20e3116d12d2583e44b08defd89e10d,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:61
-* @route '/admin/surat/{id}/reject'
-*/
-export const rejectRedirect = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: rejectRedirect.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/admin/surat/{id}/reject'
+ */
+const rejectRedirectc79b67a26e419525078af90f9b11470c = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: rejectRedirectc79b67a26e419525078af90f9b11470c.url(args, options),
     method: 'get',
 })
 
-rejectRedirect.definition = {
+rejectRedirectc79b67a26e419525078af90f9b11470c.definition = {
     methods: ["get","head"],
     url: '/admin/surat/{id}/reject',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:61
-* @route '/admin/surat/{id}/reject'
-*/
-rejectRedirect.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/admin/surat/{id}/reject'
+ */
+rejectRedirectc79b67a26e419525078af90f9b11470c.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
-    return rejectRedirect.definition.url
+    return rejectRedirectc79b67a26e419525078af90f9b11470c.definition.url
             .replace('{id}', parsedArgs.id.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:61
-* @route '/admin/surat/{id}/reject'
-*/
-rejectRedirect.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: rejectRedirect.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/admin/surat/{id}/reject'
+ */
+rejectRedirectc79b67a26e419525078af90f9b11470c.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: rejectRedirectc79b67a26e419525078af90f9b11470c.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:61
-* @route '/admin/surat/{id}/reject'
-*/
-rejectRedirect.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: rejectRedirect.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/admin/surat/{id}/reject'
+ */
+rejectRedirectc79b67a26e419525078af90f9b11470c.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: rejectRedirectc79b67a26e419525078af90f9b11470c.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/admin/surat/{id}/reject'
+ */
+    const rejectRedirectc79b67a26e419525078af90f9b11470cForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: rejectRedirectc79b67a26e419525078af90f9b11470c.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/admin/surat/{id}/reject'
+ */
+        rejectRedirectc79b67a26e419525078af90f9b11470cForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: rejectRedirectc79b67a26e419525078af90f9b11470c.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/admin/surat/{id}/reject'
+ */
+        rejectRedirectc79b67a26e419525078af90f9b11470cForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: rejectRedirectc79b67a26e419525078af90f9b11470c.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    rejectRedirectc79b67a26e419525078af90f9b11470c.form = rejectRedirectc79b67a26e419525078af90f9b11470cForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+const rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, options),
+    method: 'get',
+})
+
+rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/surat/{id}/reject',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+    const rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5aForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+        rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5aForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+        rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5aForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a.form = rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5aForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+const rejectRedirect465de78c683dcff8230fca8188657daa = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: rejectRedirect465de78c683dcff8230fca8188657daa.url(args, options),
+    method: 'get',
+})
+
+rejectRedirect465de78c683dcff8230fca8188657daa.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/surat/{id}/reject',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+rejectRedirect465de78c683dcff8230fca8188657daa.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return rejectRedirect465de78c683dcff8230fca8188657daa.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+rejectRedirect465de78c683dcff8230fca8188657daa.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: rejectRedirect465de78c683dcff8230fca8188657daa.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+rejectRedirect465de78c683dcff8230fca8188657daa.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: rejectRedirect465de78c683dcff8230fca8188657daa.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+    const rejectRedirect465de78c683dcff8230fca8188657daaForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: rejectRedirect465de78c683dcff8230fca8188657daa.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+        rejectRedirect465de78c683dcff8230fca8188657daaForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: rejectRedirect465de78c683dcff8230fca8188657daa.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:130
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+        rejectRedirect465de78c683dcff8230fca8188657daaForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: rejectRedirect465de78c683dcff8230fca8188657daa.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    rejectRedirect465de78c683dcff8230fca8188657daa.form = rejectRedirect465de78c683dcff8230fca8188657daaForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::rejectRedirect, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `rejectRedirect['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const rejectRedirect = {
+    '/admin/surat/{id}/reject': rejectRedirectc79b67a26e419525078af90f9b11470c,
+    '/kaprodi/admin/surat/{id}/reject': rejectRedirect374ba9c59f7d5b307a6e6c4a24a54a5a,
+    '/dekan/admin/surat/{id}/reject': rejectRedirect465de78c683dcff8230fca8188657daa,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:56
-* @route '/admin/surat/{id}/reject'
-*/
-export const reject = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: reject.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/admin/surat/{id}/reject'
+ */
+const rejectc79b67a26e419525078af90f9b11470c = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: rejectc79b67a26e419525078af90f9b11470c.url(args, options),
     method: 'post',
 })
 
-reject.definition = {
+rejectc79b67a26e419525078af90f9b11470c.definition = {
     methods: ["post"],
     url: '/admin/surat/{id}/reject',
 } satisfies RouteDefinition<["post"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:56
-* @route '/admin/surat/{id}/reject'
-*/
-reject.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/admin/surat/{id}/reject'
+ */
+rejectc79b67a26e419525078af90f9b11470c.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
-    return reject.definition.url
+    return rejectc79b67a26e419525078af90f9b11470c.definition.url
             .replace('{id}', parsedArgs.id.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
-* @see app/Modules/Fast/Controllers/Admin/DashboardController.php:56
-* @route '/admin/surat/{id}/reject'
-*/
-reject.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: reject.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/admin/surat/{id}/reject'
+ */
+rejectc79b67a26e419525078af90f9b11470c.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: rejectc79b67a26e419525078af90f9b11470c.url(args, options),
     method: 'post',
 })
 
-const DashboardController = { previewTemplate, previewGeneratedDocument, downloadPdf, previewAttachment, index, show, approve, rejectRedirect, reject }
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/admin/surat/{id}/reject'
+ */
+    const rejectc79b67a26e419525078af90f9b11470cForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: rejectc79b67a26e419525078af90f9b11470c.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/admin/surat/{id}/reject'
+ */
+        rejectc79b67a26e419525078af90f9b11470cForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: rejectc79b67a26e419525078af90f9b11470c.url(args, options),
+            method: 'post',
+        })
+    
+    rejectc79b67a26e419525078af90f9b11470c.form = rejectc79b67a26e419525078af90f9b11470cForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+const reject374ba9c59f7d5b307a6e6c4a24a54a5a = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: reject374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, options),
+    method: 'post',
+})
+
+reject374ba9c59f7d5b307a6e6c4a24a54a5a.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/surat/{id}/reject',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+reject374ba9c59f7d5b307a6e6c4a24a54a5a.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return reject374ba9c59f7d5b307a6e6c4a24a54a5a.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+reject374ba9c59f7d5b307a6e6c4a24a54a5a.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: reject374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+    const reject374ba9c59f7d5b307a6e6c4a24a54a5aForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: reject374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/kaprodi/admin/surat/{id}/reject'
+ */
+        reject374ba9c59f7d5b307a6e6c4a24a54a5aForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: reject374ba9c59f7d5b307a6e6c4a24a54a5a.url(args, options),
+            method: 'post',
+        })
+    
+    reject374ba9c59f7d5b307a6e6c4a24a54a5a.form = reject374ba9c59f7d5b307a6e6c4a24a54a5aForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+const reject465de78c683dcff8230fca8188657daa = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: reject465de78c683dcff8230fca8188657daa.url(args, options),
+    method: 'post',
+})
+
+reject465de78c683dcff8230fca8188657daa.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/surat/{id}/reject',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+reject465de78c683dcff8230fca8188657daa.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return reject465de78c683dcff8230fca8188657daa.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+reject465de78c683dcff8230fca8188657daa.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: reject465de78c683dcff8230fca8188657daa.url(args, options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+    const reject465de78c683dcff8230fca8188657daaForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: reject465de78c683dcff8230fca8188657daa.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\DashboardController::reject
+ * @see app/Modules/Fast/Controllers/Admin/DashboardController.php:122
+ * @route '/dekan/admin/surat/{id}/reject'
+ */
+        reject465de78c683dcff8230fca8188657daaForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: reject465de78c683dcff8230fca8188657daa.url(args, options),
+            method: 'post',
+        })
+    
+    reject465de78c683dcff8230fca8188657daa.form = reject465de78c683dcff8230fca8188657daaForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\DashboardController::reject, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `reject['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const reject = {
+    '/admin/surat/{id}/reject': rejectc79b67a26e419525078af90f9b11470c,
+    '/kaprodi/admin/surat/{id}/reject': reject374ba9c59f7d5b307a6e6c4a24a54a5a,
+    '/dekan/admin/surat/{id}/reject': reject465de78c683dcff8230fca8188657daa,
+}
+
+const DashboardController = { previewTemplate, previewGeneratedDocument, downloadPdf, previewAttachmentDocument, downloadAttachmentPdf, previewAttachment, index, show, bulkApprove, approve, rejectRedirect, reject }
 
 export default DashboardController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/GlobalSettingsController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/GlobalSettingsController.ts
@@ -1,81 +1,426 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
-* @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:39
-* @route '/admin/settings/template'
-*/
-export const save = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: save.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/admin/settings/template'
+ */
+const save2dfa4b2077acf3792e3877e8343031c0 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: save2dfa4b2077acf3792e3877e8343031c0.url(options),
     method: 'post',
 })
 
-save.definition = {
+save2dfa4b2077acf3792e3877e8343031c0.definition = {
     methods: ["post"],
     url: '/admin/settings/template',
 } satisfies RouteDefinition<["post"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
-* @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:39
-* @route '/admin/settings/template'
-*/
-save.url = (options?: RouteQueryOptions) => {
-    return save.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/admin/settings/template'
+ */
+save2dfa4b2077acf3792e3877e8343031c0.url = (options?: RouteQueryOptions) => {
+    return save2dfa4b2077acf3792e3877e8343031c0.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
-* @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:39
-* @route '/admin/settings/template'
-*/
-save.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: save.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/admin/settings/template'
+ */
+save2dfa4b2077acf3792e3877e8343031c0.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: save2dfa4b2077acf3792e3877e8343031c0.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/admin/settings/template'
+ */
+    const save2dfa4b2077acf3792e3877e8343031c0Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: save2dfa4b2077acf3792e3877e8343031c0.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/admin/settings/template'
+ */
+        save2dfa4b2077acf3792e3877e8343031c0Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: save2dfa4b2077acf3792e3877e8343031c0.url(options),
+            method: 'post',
+        })
+    
+    save2dfa4b2077acf3792e3877e8343031c0.form = save2dfa4b2077acf3792e3877e8343031c0Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/kaprodi/admin/settings/template'
+ */
+const save20dfbf2fa591d06e40e119b749465e84 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: save20dfbf2fa591d06e40e119b749465e84.url(options),
+    method: 'post',
+})
+
+save20dfbf2fa591d06e40e119b749465e84.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/settings/template',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/kaprodi/admin/settings/template'
+ */
+save20dfbf2fa591d06e40e119b749465e84.url = (options?: RouteQueryOptions) => {
+    return save20dfbf2fa591d06e40e119b749465e84.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/kaprodi/admin/settings/template'
+ */
+save20dfbf2fa591d06e40e119b749465e84.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: save20dfbf2fa591d06e40e119b749465e84.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/kaprodi/admin/settings/template'
+ */
+    const save20dfbf2fa591d06e40e119b749465e84Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: save20dfbf2fa591d06e40e119b749465e84.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/kaprodi/admin/settings/template'
+ */
+        save20dfbf2fa591d06e40e119b749465e84Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: save20dfbf2fa591d06e40e119b749465e84.url(options),
+            method: 'post',
+        })
+    
+    save20dfbf2fa591d06e40e119b749465e84.form = save20dfbf2fa591d06e40e119b749465e84Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/dekan/admin/settings/template'
+ */
+const savefd82f972326d00b3e471ea88ea953ba5 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: savefd82f972326d00b3e471ea88ea953ba5.url(options),
+    method: 'post',
+})
+
+savefd82f972326d00b3e471ea88ea953ba5.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/settings/template',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/dekan/admin/settings/template'
+ */
+savefd82f972326d00b3e471ea88ea953ba5.url = (options?: RouteQueryOptions) => {
+    return savefd82f972326d00b3e471ea88ea953ba5.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/dekan/admin/settings/template'
+ */
+savefd82f972326d00b3e471ea88ea953ba5.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: savefd82f972326d00b3e471ea88ea953ba5.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/dekan/admin/settings/template'
+ */
+    const savefd82f972326d00b3e471ea88ea953ba5Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: savefd82f972326d00b3e471ea88ea953ba5.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:41
+ * @route '/dekan/admin/settings/template'
+ */
+        savefd82f972326d00b3e471ea88ea953ba5Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: savefd82f972326d00b3e471ea88ea953ba5.url(options),
+            method: 'post',
+        })
+    
+    savefd82f972326d00b3e471ea88ea953ba5.form = savefd82f972326d00b3e471ea88ea953ba5Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::save, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `save['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const save = {
+    '/admin/settings/template': save2dfa4b2077acf3792e3877e8343031c0,
+    '/kaprodi/admin/settings/template': save20dfbf2fa591d06e40e119b749465e84,
+    '/dekan/admin/settings/template': savefd82f972326d00b3e471ea88ea953ba5,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
-* @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
-* @route '/admin/settings/template/logo-preview'
-*/
-export const previewLogo = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: previewLogo.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/admin/settings/template/logo-preview'
+ */
+const previewLogoa939e3f916d454fe26eebc11dbbc60f2 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewLogoa939e3f916d454fe26eebc11dbbc60f2.url(options),
     method: 'get',
 })
 
-previewLogo.definition = {
+previewLogoa939e3f916d454fe26eebc11dbbc60f2.definition = {
     methods: ["get","head"],
     url: '/admin/settings/template/logo-preview',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
-* @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
-* @route '/admin/settings/template/logo-preview'
-*/
-previewLogo.url = (options?: RouteQueryOptions) => {
-    return previewLogo.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/admin/settings/template/logo-preview'
+ */
+previewLogoa939e3f916d454fe26eebc11dbbc60f2.url = (options?: RouteQueryOptions) => {
+    return previewLogoa939e3f916d454fe26eebc11dbbc60f2.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
-* @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
-* @route '/admin/settings/template/logo-preview'
-*/
-previewLogo.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: previewLogo.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/admin/settings/template/logo-preview'
+ */
+previewLogoa939e3f916d454fe26eebc11dbbc60f2.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewLogoa939e3f916d454fe26eebc11dbbc60f2.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/admin/settings/template/logo-preview'
+ */
+previewLogoa939e3f916d454fe26eebc11dbbc60f2.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewLogoa939e3f916d454fe26eebc11dbbc60f2.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/admin/settings/template/logo-preview'
+ */
+    const previewLogoa939e3f916d454fe26eebc11dbbc60f2Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewLogoa939e3f916d454fe26eebc11dbbc60f2.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/admin/settings/template/logo-preview'
+ */
+        previewLogoa939e3f916d454fe26eebc11dbbc60f2Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewLogoa939e3f916d454fe26eebc11dbbc60f2.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/admin/settings/template/logo-preview'
+ */
+        previewLogoa939e3f916d454fe26eebc11dbbc60f2Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewLogoa939e3f916d454fe26eebc11dbbc60f2.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewLogoa939e3f916d454fe26eebc11dbbc60f2.form = previewLogoa939e3f916d454fe26eebc11dbbc60f2Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/kaprodi/admin/settings/template/logo-preview'
+ */
+const previewLogo7d354da9cfd70d8ec0ac103079938964 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewLogo7d354da9cfd70d8ec0ac103079938964.url(options),
     method: 'get',
 })
 
+previewLogo7d354da9cfd70d8ec0ac103079938964.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/settings/template/logo-preview',
+} satisfies RouteDefinition<["get","head"]>
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
-* @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
-* @route '/admin/settings/template/logo-preview'
-*/
-previewLogo.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: previewLogo.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/kaprodi/admin/settings/template/logo-preview'
+ */
+previewLogo7d354da9cfd70d8ec0ac103079938964.url = (options?: RouteQueryOptions) => {
+    return previewLogo7d354da9cfd70d8ec0ac103079938964.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/kaprodi/admin/settings/template/logo-preview'
+ */
+previewLogo7d354da9cfd70d8ec0ac103079938964.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewLogo7d354da9cfd70d8ec0ac103079938964.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/kaprodi/admin/settings/template/logo-preview'
+ */
+previewLogo7d354da9cfd70d8ec0ac103079938964.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewLogo7d354da9cfd70d8ec0ac103079938964.url(options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/kaprodi/admin/settings/template/logo-preview'
+ */
+    const previewLogo7d354da9cfd70d8ec0ac103079938964Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewLogo7d354da9cfd70d8ec0ac103079938964.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/kaprodi/admin/settings/template/logo-preview'
+ */
+        previewLogo7d354da9cfd70d8ec0ac103079938964Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewLogo7d354da9cfd70d8ec0ac103079938964.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/kaprodi/admin/settings/template/logo-preview'
+ */
+        previewLogo7d354da9cfd70d8ec0ac103079938964Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewLogo7d354da9cfd70d8ec0ac103079938964.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewLogo7d354da9cfd70d8ec0ac103079938964.form = previewLogo7d354da9cfd70d8ec0ac103079938964Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/dekan/admin/settings/template/logo-preview'
+ */
+const previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.url(options),
+    method: 'get',
+})
+
+previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/settings/template/logo-preview',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/dekan/admin/settings/template/logo-preview'
+ */
+previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.url = (options?: RouteQueryOptions) => {
+    return previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/dekan/admin/settings/template/logo-preview'
+ */
+previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/dekan/admin/settings/template/logo-preview'
+ */
+previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/dekan/admin/settings/template/logo-preview'
+ */
+    const previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/dekan/admin/settings/template/logo-preview'
+ */
+        previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo
+ * @see app/Modules/Fast/Controllers/Admin/GlobalSettingsController.php:15
+ * @route '/dekan/admin/settings/template/logo-preview'
+ */
+        previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869.form = previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\GlobalSettingsController::previewLogo, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `previewLogo['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const previewLogo = {
+    '/admin/settings/template/logo-preview': previewLogoa939e3f916d454fe26eebc11dbbc60f2,
+    '/kaprodi/admin/settings/template/logo-preview': previewLogo7d354da9cfd70d8ec0ac103079938964,
+    '/dekan/admin/settings/template/logo-preview': previewLogo9eb4b7eb5c948d4a4bb5f17bf3704869,
+}
 
 const GlobalSettingsController = { save, previewLogo }
 

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/HistoryController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/HistoryController.ts
@@ -1,47 +1,249 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
-* @see app/Modules/Fast/Controllers/Admin/HistoryController.php:14
-* @route '/admin/history'
-*/
-export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/admin/history'
+ */
+const index712511a254a7dfe7f3332db4142a47d9 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index712511a254a7dfe7f3332db4142a47d9.url(options),
     method: 'get',
 })
 
-index.definition = {
+index712511a254a7dfe7f3332db4142a47d9.definition = {
     methods: ["get","head"],
     url: '/admin/history',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
-* @see app/Modules/Fast/Controllers/Admin/HistoryController.php:14
-* @route '/admin/history'
-*/
-index.url = (options?: RouteQueryOptions) => {
-    return index.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/admin/history'
+ */
+index712511a254a7dfe7f3332db4142a47d9.url = (options?: RouteQueryOptions) => {
+    return index712511a254a7dfe7f3332db4142a47d9.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
-* @see app/Modules/Fast/Controllers/Admin/HistoryController.php:14
-* @route '/admin/history'
-*/
-index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/admin/history'
+ */
+index712511a254a7dfe7f3332db4142a47d9.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index712511a254a7dfe7f3332db4142a47d9.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/admin/history'
+ */
+index712511a254a7dfe7f3332db4142a47d9.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index712511a254a7dfe7f3332db4142a47d9.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/admin/history'
+ */
+    const index712511a254a7dfe7f3332db4142a47d9Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index712511a254a7dfe7f3332db4142a47d9.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/admin/history'
+ */
+        index712511a254a7dfe7f3332db4142a47d9Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index712511a254a7dfe7f3332db4142a47d9.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/admin/history'
+ */
+        index712511a254a7dfe7f3332db4142a47d9Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index712511a254a7dfe7f3332db4142a47d9.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index712511a254a7dfe7f3332db4142a47d9.form = index712511a254a7dfe7f3332db4142a47d9Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/kaprodi/admin/history'
+ */
+const index53f298859ccc2f4dcada3a2e3ebc0d43 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index53f298859ccc2f4dcada3a2e3ebc0d43.url(options),
     method: 'get',
 })
 
+index53f298859ccc2f4dcada3a2e3ebc0d43.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/history',
+} satisfies RouteDefinition<["get","head"]>
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
-* @see app/Modules/Fast/Controllers/Admin/HistoryController.php:14
-* @route '/admin/history'
-*/
-index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/kaprodi/admin/history'
+ */
+index53f298859ccc2f4dcada3a2e3ebc0d43.url = (options?: RouteQueryOptions) => {
+    return index53f298859ccc2f4dcada3a2e3ebc0d43.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/kaprodi/admin/history'
+ */
+index53f298859ccc2f4dcada3a2e3ebc0d43.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index53f298859ccc2f4dcada3a2e3ebc0d43.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/kaprodi/admin/history'
+ */
+index53f298859ccc2f4dcada3a2e3ebc0d43.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index53f298859ccc2f4dcada3a2e3ebc0d43.url(options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/kaprodi/admin/history'
+ */
+    const index53f298859ccc2f4dcada3a2e3ebc0d43Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index53f298859ccc2f4dcada3a2e3ebc0d43.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/kaprodi/admin/history'
+ */
+        index53f298859ccc2f4dcada3a2e3ebc0d43Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index53f298859ccc2f4dcada3a2e3ebc0d43.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/kaprodi/admin/history'
+ */
+        index53f298859ccc2f4dcada3a2e3ebc0d43Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index53f298859ccc2f4dcada3a2e3ebc0d43.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index53f298859ccc2f4dcada3a2e3ebc0d43.form = index53f298859ccc2f4dcada3a2e3ebc0d43Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/dekan/admin/history'
+ */
+const indexb09fcad8e23f39d34728cc5e24fd4377 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexb09fcad8e23f39d34728cc5e24fd4377.url(options),
+    method: 'get',
+})
+
+indexb09fcad8e23f39d34728cc5e24fd4377.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/history',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/dekan/admin/history'
+ */
+indexb09fcad8e23f39d34728cc5e24fd4377.url = (options?: RouteQueryOptions) => {
+    return indexb09fcad8e23f39d34728cc5e24fd4377.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/dekan/admin/history'
+ */
+indexb09fcad8e23f39d34728cc5e24fd4377.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexb09fcad8e23f39d34728cc5e24fd4377.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/dekan/admin/history'
+ */
+indexb09fcad8e23f39d34728cc5e24fd4377.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexb09fcad8e23f39d34728cc5e24fd4377.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/dekan/admin/history'
+ */
+    const indexb09fcad8e23f39d34728cc5e24fd4377Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexb09fcad8e23f39d34728cc5e24fd4377.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/dekan/admin/history'
+ */
+        indexb09fcad8e23f39d34728cc5e24fd4377Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexb09fcad8e23f39d34728cc5e24fd4377.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Admin/HistoryController.php:15
+ * @route '/dekan/admin/history'
+ */
+        indexb09fcad8e23f39d34728cc5e24fd4377Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexb09fcad8e23f39d34728cc5e24fd4377.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexb09fcad8e23f39d34728cc5e24fd4377.form = indexb09fcad8e23f39d34728cc5e24fd4377Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\HistoryController::index, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `index['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const index = {
+    '/admin/history': index712511a254a7dfe7f3332db4142a47d9,
+    '/kaprodi/admin/history': index53f298859ccc2f4dcada3a2e3ebc0d43,
+    '/dekan/admin/history': indexb09fcad8e23f39d34728cc5e24fd4377,
+}
 
 const HistoryController = { index }
 

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/LetterController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/LetterController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:182
-* @route '/documents/surat/{id}/generate'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/documents/surat/{id}/generate'
+ */
 const generate4dc0087b29b62374302632a274ce7cf8 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: generate4dc0087b29b62374302632a274ce7cf8.url(args, options),
     method: 'get',
@@ -16,25 +16,26 @@ generate4dc0087b29b62374302632a274ce7cf8.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:182
-* @route '/documents/surat/{id}/generate'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/documents/surat/{id}/generate'
+ */
 generate4dc0087b29b62374302632a274ce7cf8.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return generate4dc0087b29b62374302632a274ce7cf8.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -43,29 +44,63 @@ generate4dc0087b29b62374302632a274ce7cf8.url = (args: { id: string | number } | 
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:182
-* @route '/documents/surat/{id}/generate'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/documents/surat/{id}/generate'
+ */
 generate4dc0087b29b62374302632a274ce7cf8.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: generate4dc0087b29b62374302632a274ce7cf8.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:182
-* @route '/documents/surat/{id}/generate'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/documents/surat/{id}/generate'
+ */
 generate4dc0087b29b62374302632a274ce7cf8.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: generate4dc0087b29b62374302632a274ce7cf8.url(args, options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:182
-* @route '/admin/surat/{id}/generate'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/documents/surat/{id}/generate'
+ */
+    const generate4dc0087b29b62374302632a274ce7cf8Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: generate4dc0087b29b62374302632a274ce7cf8.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/documents/surat/{id}/generate'
+ */
+        generate4dc0087b29b62374302632a274ce7cf8Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: generate4dc0087b29b62374302632a274ce7cf8.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/documents/surat/{id}/generate'
+ */
+        generate4dc0087b29b62374302632a274ce7cf8Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: generate4dc0087b29b62374302632a274ce7cf8.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    generate4dc0087b29b62374302632a274ce7cf8.form = generate4dc0087b29b62374302632a274ce7cf8Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/admin/surat/{id}/generate'
+ */
 const generate03a498acc6b7534dc5a6f2f7299d0045 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: generate03a498acc6b7534dc5a6f2f7299d0045.url(args, options),
     method: 'get',
@@ -78,25 +113,26 @@ generate03a498acc6b7534dc5a6f2f7299d0045.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:182
-* @route '/admin/surat/{id}/generate'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/admin/surat/{id}/generate'
+ */
 generate03a498acc6b7534dc5a6f2f7299d0045.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return generate03a498acc6b7534dc5a6f2f7299d0045.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -105,23 +141,58 @@ generate03a498acc6b7534dc5a6f2f7299d0045.url = (args: { id: string | number } | 
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:182
-* @route '/admin/surat/{id}/generate'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/admin/surat/{id}/generate'
+ */
 generate03a498acc6b7534dc5a6f2f7299d0045.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: generate03a498acc6b7534dc5a6f2f7299d0045.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:182
-* @route '/admin/surat/{id}/generate'
-*/
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/admin/surat/{id}/generate'
+ */
 generate03a498acc6b7534dc5a6f2f7299d0045.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: generate03a498acc6b7534dc5a6f2f7299d0045.url(args, options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/admin/surat/{id}/generate'
+ */
+    const generate03a498acc6b7534dc5a6f2f7299d0045Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: generate03a498acc6b7534dc5a6f2f7299d0045.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/admin/surat/{id}/generate'
+ */
+        generate03a498acc6b7534dc5a6f2f7299d0045Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: generate03a498acc6b7534dc5a6f2f7299d0045.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::generate
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:245
+ * @route '/admin/surat/{id}/generate'
+ */
+        generate03a498acc6b7534dc5a6f2f7299d0045Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: generate03a498acc6b7534dc5a6f2f7299d0045.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    generate03a498acc6b7534dc5a6f2f7299d0045.form = generate03a498acc6b7534dc5a6f2f7299d0045Form
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::generate, so this export is a
@@ -135,376 +206,2404 @@ export const generate = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::create
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:26
-* @route '/admin/surat/create'
-*/
-export const create = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: create.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/admin/surat/create'
+ */
+const create1426ee4ccb383d4ff8a8c5c14ffb6fb5 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: create1426ee4ccb383d4ff8a8c5c14ffb6fb5.url(options),
     method: 'get',
 })
 
-create.definition = {
+create1426ee4ccb383d4ff8a8c5c14ffb6fb5.definition = {
     methods: ["get","head"],
     url: '/admin/surat/create',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::create
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:26
-* @route '/admin/surat/create'
-*/
-create.url = (options?: RouteQueryOptions) => {
-    return create.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/admin/surat/create'
+ */
+create1426ee4ccb383d4ff8a8c5c14ffb6fb5.url = (options?: RouteQueryOptions) => {
+    return create1426ee4ccb383d4ff8a8c5c14ffb6fb5.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::create
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:26
-* @route '/admin/surat/create'
-*/
-create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: create.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/admin/surat/create'
+ */
+create1426ee4ccb383d4ff8a8c5c14ffb6fb5.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: create1426ee4ccb383d4ff8a8c5c14ffb6fb5.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::create
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:26
-* @route '/admin/surat/create'
-*/
-create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: create.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/admin/surat/create'
+ */
+create1426ee4ccb383d4ff8a8c5c14ffb6fb5.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: create1426ee4ccb383d4ff8a8c5c14ffb6fb5.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/admin/surat/create'
+ */
+    const create1426ee4ccb383d4ff8a8c5c14ffb6fb5Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: create1426ee4ccb383d4ff8a8c5c14ffb6fb5.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/admin/surat/create'
+ */
+        create1426ee4ccb383d4ff8a8c5c14ffb6fb5Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create1426ee4ccb383d4ff8a8c5c14ffb6fb5.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/admin/surat/create'
+ */
+        create1426ee4ccb383d4ff8a8c5c14ffb6fb5Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create1426ee4ccb383d4ff8a8c5c14ffb6fb5.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    create1426ee4ccb383d4ff8a8c5c14ffb6fb5.form = create1426ee4ccb383d4ff8a8c5c14ffb6fb5Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/kaprodi/admin/surat/create'
+ */
+const created5f64d2b7060ece2769fbec7bee33745 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: created5f64d2b7060ece2769fbec7bee33745.url(options),
+    method: 'get',
+})
+
+created5f64d2b7060ece2769fbec7bee33745.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/surat/create',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/kaprodi/admin/surat/create'
+ */
+created5f64d2b7060ece2769fbec7bee33745.url = (options?: RouteQueryOptions) => {
+    return created5f64d2b7060ece2769fbec7bee33745.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/kaprodi/admin/surat/create'
+ */
+created5f64d2b7060ece2769fbec7bee33745.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: created5f64d2b7060ece2769fbec7bee33745.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/kaprodi/admin/surat/create'
+ */
+created5f64d2b7060ece2769fbec7bee33745.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: created5f64d2b7060ece2769fbec7bee33745.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/kaprodi/admin/surat/create'
+ */
+    const created5f64d2b7060ece2769fbec7bee33745Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: created5f64d2b7060ece2769fbec7bee33745.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/kaprodi/admin/surat/create'
+ */
+        created5f64d2b7060ece2769fbec7bee33745Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: created5f64d2b7060ece2769fbec7bee33745.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/kaprodi/admin/surat/create'
+ */
+        created5f64d2b7060ece2769fbec7bee33745Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: created5f64d2b7060ece2769fbec7bee33745.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    created5f64d2b7060ece2769fbec7bee33745.form = created5f64d2b7060ece2769fbec7bee33745Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/dekan/admin/surat/create'
+ */
+const createf1e25c0457bd48e673c5f72f8ac1e66d = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: createf1e25c0457bd48e673c5f72f8ac1e66d.url(options),
+    method: 'get',
+})
+
+createf1e25c0457bd48e673c5f72f8ac1e66d.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/surat/create',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/dekan/admin/surat/create'
+ */
+createf1e25c0457bd48e673c5f72f8ac1e66d.url = (options?: RouteQueryOptions) => {
+    return createf1e25c0457bd48e673c5f72f8ac1e66d.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/dekan/admin/surat/create'
+ */
+createf1e25c0457bd48e673c5f72f8ac1e66d.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: createf1e25c0457bd48e673c5f72f8ac1e66d.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/dekan/admin/surat/create'
+ */
+createf1e25c0457bd48e673c5f72f8ac1e66d.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: createf1e25c0457bd48e673c5f72f8ac1e66d.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/dekan/admin/surat/create'
+ */
+    const createf1e25c0457bd48e673c5f72f8ac1e66dForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: createf1e25c0457bd48e673c5f72f8ac1e66d.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/dekan/admin/surat/create'
+ */
+        createf1e25c0457bd48e673c5f72f8ac1e66dForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: createf1e25c0457bd48e673c5f72f8ac1e66d.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::create
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:35
+ * @route '/dekan/admin/surat/create'
+ */
+        createf1e25c0457bd48e673c5f72f8ac1e66dForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: createf1e25c0457bd48e673c5f72f8ac1e66d.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    createf1e25c0457bd48e673c5f72f8ac1e66d.form = createf1e25c0457bd48e673c5f72f8ac1e66dForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::create, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `create['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const create = {
+    '/admin/surat/create': create1426ee4ccb383d4ff8a8c5c14ffb6fb5,
+    '/kaprodi/admin/surat/create': created5f64d2b7060ece2769fbec7bee33745,
+    '/dekan/admin/surat/create': createf1e25c0457bd48e673c5f72f8ac1e66d,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:55
-* @route '/admin/surat/select-type'
-*/
-export const selectType = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: selectType.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/admin/surat/select-type'
+ */
+const selectTypee4f35a3e04d1cd196550ba29ddccef8f = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: selectTypee4f35a3e04d1cd196550ba29ddccef8f.url(options),
     method: 'post',
 })
 
-selectType.definition = {
+selectTypee4f35a3e04d1cd196550ba29ddccef8f.definition = {
     methods: ["post"],
     url: '/admin/surat/select-type',
 } satisfies RouteDefinition<["post"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:55
-* @route '/admin/surat/select-type'
-*/
-selectType.url = (options?: RouteQueryOptions) => {
-    return selectType.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/admin/surat/select-type'
+ */
+selectTypee4f35a3e04d1cd196550ba29ddccef8f.url = (options?: RouteQueryOptions) => {
+    return selectTypee4f35a3e04d1cd196550ba29ddccef8f.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:55
-* @route '/admin/surat/select-type'
-*/
-selectType.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: selectType.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/admin/surat/select-type'
+ */
+selectTypee4f35a3e04d1cd196550ba29ddccef8f.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: selectTypee4f35a3e04d1cd196550ba29ddccef8f.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/admin/surat/select-type'
+ */
+    const selectTypee4f35a3e04d1cd196550ba29ddccef8fForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: selectTypee4f35a3e04d1cd196550ba29ddccef8f.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/admin/surat/select-type'
+ */
+        selectTypee4f35a3e04d1cd196550ba29ddccef8fForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: selectTypee4f35a3e04d1cd196550ba29ddccef8f.url(options),
+            method: 'post',
+        })
+    
+    selectTypee4f35a3e04d1cd196550ba29ddccef8f.form = selectTypee4f35a3e04d1cd196550ba29ddccef8fForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/kaprodi/admin/surat/select-type'
+ */
+const selectType321985e3a63edca923836f6db80e5b5d = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: selectType321985e3a63edca923836f6db80e5b5d.url(options),
+    method: 'post',
+})
+
+selectType321985e3a63edca923836f6db80e5b5d.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/surat/select-type',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/kaprodi/admin/surat/select-type'
+ */
+selectType321985e3a63edca923836f6db80e5b5d.url = (options?: RouteQueryOptions) => {
+    return selectType321985e3a63edca923836f6db80e5b5d.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/kaprodi/admin/surat/select-type'
+ */
+selectType321985e3a63edca923836f6db80e5b5d.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: selectType321985e3a63edca923836f6db80e5b5d.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/kaprodi/admin/surat/select-type'
+ */
+    const selectType321985e3a63edca923836f6db80e5b5dForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: selectType321985e3a63edca923836f6db80e5b5d.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/kaprodi/admin/surat/select-type'
+ */
+        selectType321985e3a63edca923836f6db80e5b5dForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: selectType321985e3a63edca923836f6db80e5b5d.url(options),
+            method: 'post',
+        })
+    
+    selectType321985e3a63edca923836f6db80e5b5d.form = selectType321985e3a63edca923836f6db80e5b5dForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/dekan/admin/surat/select-type'
+ */
+const selectTypef4bcebf31a3868b44e141d46218e93e1 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: selectTypef4bcebf31a3868b44e141d46218e93e1.url(options),
+    method: 'post',
+})
+
+selectTypef4bcebf31a3868b44e141d46218e93e1.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/surat/select-type',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/dekan/admin/surat/select-type'
+ */
+selectTypef4bcebf31a3868b44e141d46218e93e1.url = (options?: RouteQueryOptions) => {
+    return selectTypef4bcebf31a3868b44e141d46218e93e1.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/dekan/admin/surat/select-type'
+ */
+selectTypef4bcebf31a3868b44e141d46218e93e1.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: selectTypef4bcebf31a3868b44e141d46218e93e1.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/dekan/admin/surat/select-type'
+ */
+    const selectTypef4bcebf31a3868b44e141d46218e93e1Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: selectTypef4bcebf31a3868b44e141d46218e93e1.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::selectType
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:71
+ * @route '/dekan/admin/surat/select-type'
+ */
+        selectTypef4bcebf31a3868b44e141d46218e93e1Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: selectTypef4bcebf31a3868b44e141d46218e93e1.url(options),
+            method: 'post',
+        })
+    
+    selectTypef4bcebf31a3868b44e141d46218e93e1.form = selectTypef4bcebf31a3868b44e141d46218e93e1Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::selectType, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `selectType['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const selectType = {
+    '/admin/surat/select-type': selectTypee4f35a3e04d1cd196550ba29ddccef8f,
+    '/kaprodi/admin/surat/select-type': selectType321985e3a63edca923836f6db80e5b5d,
+    '/dekan/admin/surat/select-type': selectTypef4bcebf31a3868b44e141d46218e93e1,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::form
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:68
-* @route '/admin/surat/form/{jenisSurat}'
-*/
-export const form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: form.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/admin/surat/form/{jenisSurat}'
+ */
+const form8a79520a8d6806df604bfe52baf7f53c = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: form8a79520a8d6806df604bfe52baf7f53c.url(args, options),
     method: 'get',
 })
 
-form.definition = {
+form8a79520a8d6806df604bfe52baf7f53c.definition = {
     methods: ["get","head"],
     url: '/admin/surat/form/{jenisSurat}',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::form
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:68
-* @route '/admin/surat/form/{jenisSurat}'
-*/
-form.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/admin/surat/form/{jenisSurat}'
+ */
+form8a79520a8d6806df604bfe52baf7f53c.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { jenisSurat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { jenisSurat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            jenisSurat: args[0],
-        }
+                    jenisSurat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        jenisSurat: typeof args.jenisSurat === 'object'
-        ? args.jenisSurat.id
-        : args.jenisSurat,
-    }
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
 
-    return form.definition.url
+    return form8a79520a8d6806df604bfe52baf7f53c.definition.url
             .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::form
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:68
-* @route '/admin/surat/form/{jenisSurat}'
-*/
-form.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: form.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/admin/surat/form/{jenisSurat}'
+ */
+form8a79520a8d6806df604bfe52baf7f53c.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: form8a79520a8d6806df604bfe52baf7f53c.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::form
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:68
-* @route '/admin/surat/form/{jenisSurat}'
-*/
-form.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: form.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/admin/surat/form/{jenisSurat}'
+ */
+form8a79520a8d6806df604bfe52baf7f53c.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: form8a79520a8d6806df604bfe52baf7f53c.url(args, options),
     method: 'head',
 })
 
-/**
-* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:97
-* @route '/admin/surat/preview'
-*/
-export const previewPage = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: previewPage.url(options),
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/admin/surat/form/{jenisSurat}'
+ */
+    const form8a79520a8d6806df604bfe52baf7f53cForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: form8a79520a8d6806df604bfe52baf7f53c.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/admin/surat/form/{jenisSurat}'
+ */
+        form8a79520a8d6806df604bfe52baf7f53cForm.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: form8a79520a8d6806df604bfe52baf7f53c.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/admin/surat/form/{jenisSurat}'
+ */
+        form8a79520a8d6806df604bfe52baf7f53cForm.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: form8a79520a8d6806df604bfe52baf7f53c.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    form8a79520a8d6806df604bfe52baf7f53c.form = form8a79520a8d6806df604bfe52baf7f53cForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/kaprodi/admin/surat/form/{jenisSurat}'
+ */
+const formc2b51663df625bc828b8904c869e68d8 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: formc2b51663df625bc828b8904c869e68d8.url(args, options),
     method: 'get',
 })
 
-previewPage.definition = {
+formc2b51663df625bc828b8904c869e68d8.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/surat/form/{jenisSurat}',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/kaprodi/admin/surat/form/{jenisSurat}'
+ */
+formc2b51663df625bc828b8904c869e68d8.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return formc2b51663df625bc828b8904c869e68d8.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/kaprodi/admin/surat/form/{jenisSurat}'
+ */
+formc2b51663df625bc828b8904c869e68d8.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: formc2b51663df625bc828b8904c869e68d8.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/kaprodi/admin/surat/form/{jenisSurat}'
+ */
+formc2b51663df625bc828b8904c869e68d8.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: formc2b51663df625bc828b8904c869e68d8.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/kaprodi/admin/surat/form/{jenisSurat}'
+ */
+    const formc2b51663df625bc828b8904c869e68d8Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: formc2b51663df625bc828b8904c869e68d8.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/kaprodi/admin/surat/form/{jenisSurat}'
+ */
+        formc2b51663df625bc828b8904c869e68d8Form.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: formc2b51663df625bc828b8904c869e68d8.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/kaprodi/admin/surat/form/{jenisSurat}'
+ */
+        formc2b51663df625bc828b8904c869e68d8Form.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: formc2b51663df625bc828b8904c869e68d8.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    formc2b51663df625bc828b8904c869e68d8.form = formc2b51663df625bc828b8904c869e68d8Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/dekan/admin/surat/form/{jenisSurat}'
+ */
+const form4f3b4e5881682e7e9b354ec2e13e3e37 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: form4f3b4e5881682e7e9b354ec2e13e3e37.url(args, options),
+    method: 'get',
+})
+
+form4f3b4e5881682e7e9b354ec2e13e3e37.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/surat/form/{jenisSurat}',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/dekan/admin/surat/form/{jenisSurat}'
+ */
+form4f3b4e5881682e7e9b354ec2e13e3e37.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return form4f3b4e5881682e7e9b354ec2e13e3e37.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/dekan/admin/surat/form/{jenisSurat}'
+ */
+form4f3b4e5881682e7e9b354ec2e13e3e37.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: form4f3b4e5881682e7e9b354ec2e13e3e37.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/dekan/admin/surat/form/{jenisSurat}'
+ */
+form4f3b4e5881682e7e9b354ec2e13e3e37.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: form4f3b4e5881682e7e9b354ec2e13e3e37.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/dekan/admin/surat/form/{jenisSurat}'
+ */
+    const form4f3b4e5881682e7e9b354ec2e13e3e37Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: form4f3b4e5881682e7e9b354ec2e13e3e37.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/dekan/admin/surat/form/{jenisSurat}'
+ */
+        form4f3b4e5881682e7e9b354ec2e13e3e37Form.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: form4f3b4e5881682e7e9b354ec2e13e3e37.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::form
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:86
+ * @route '/dekan/admin/surat/form/{jenisSurat}'
+ */
+        form4f3b4e5881682e7e9b354ec2e13e3e37Form.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: form4f3b4e5881682e7e9b354ec2e13e3e37.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    form4f3b4e5881682e7e9b354ec2e13e3e37.form = form4f3b4e5881682e7e9b354ec2e13e3e37Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::form, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `form['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const form = {
+    '/admin/surat/form/{jenisSurat}': form8a79520a8d6806df604bfe52baf7f53c,
+    '/kaprodi/admin/surat/form/{jenisSurat}': formc2b51663df625bc828b8904c869e68d8,
+    '/dekan/admin/surat/form/{jenisSurat}': form4f3b4e5881682e7e9b354ec2e13e3e37,
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/admin/surat/subjects/search'
+ */
+const searchSubjects5a89c56f5141a7a384a5ba62957d4181 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: searchSubjects5a89c56f5141a7a384a5ba62957d4181.url(options),
+    method: 'get',
+})
+
+searchSubjects5a89c56f5141a7a384a5ba62957d4181.definition = {
+    methods: ["get","head"],
+    url: '/admin/surat/subjects/search',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/admin/surat/subjects/search'
+ */
+searchSubjects5a89c56f5141a7a384a5ba62957d4181.url = (options?: RouteQueryOptions) => {
+    return searchSubjects5a89c56f5141a7a384a5ba62957d4181.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/admin/surat/subjects/search'
+ */
+searchSubjects5a89c56f5141a7a384a5ba62957d4181.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: searchSubjects5a89c56f5141a7a384a5ba62957d4181.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/admin/surat/subjects/search'
+ */
+searchSubjects5a89c56f5141a7a384a5ba62957d4181.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: searchSubjects5a89c56f5141a7a384a5ba62957d4181.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/admin/surat/subjects/search'
+ */
+    const searchSubjects5a89c56f5141a7a384a5ba62957d4181Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: searchSubjects5a89c56f5141a7a384a5ba62957d4181.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/admin/surat/subjects/search'
+ */
+        searchSubjects5a89c56f5141a7a384a5ba62957d4181Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: searchSubjects5a89c56f5141a7a384a5ba62957d4181.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/admin/surat/subjects/search'
+ */
+        searchSubjects5a89c56f5141a7a384a5ba62957d4181Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: searchSubjects5a89c56f5141a7a384a5ba62957d4181.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    searchSubjects5a89c56f5141a7a384a5ba62957d4181.form = searchSubjects5a89c56f5141a7a384a5ba62957d4181Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/kaprodi/admin/surat/subjects/search'
+ */
+const searchSubjects5f083eac81bef1da2162e0a3288e6e17 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: searchSubjects5f083eac81bef1da2162e0a3288e6e17.url(options),
+    method: 'get',
+})
+
+searchSubjects5f083eac81bef1da2162e0a3288e6e17.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/surat/subjects/search',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/kaprodi/admin/surat/subjects/search'
+ */
+searchSubjects5f083eac81bef1da2162e0a3288e6e17.url = (options?: RouteQueryOptions) => {
+    return searchSubjects5f083eac81bef1da2162e0a3288e6e17.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/kaprodi/admin/surat/subjects/search'
+ */
+searchSubjects5f083eac81bef1da2162e0a3288e6e17.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: searchSubjects5f083eac81bef1da2162e0a3288e6e17.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/kaprodi/admin/surat/subjects/search'
+ */
+searchSubjects5f083eac81bef1da2162e0a3288e6e17.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: searchSubjects5f083eac81bef1da2162e0a3288e6e17.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/kaprodi/admin/surat/subjects/search'
+ */
+    const searchSubjects5f083eac81bef1da2162e0a3288e6e17Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: searchSubjects5f083eac81bef1da2162e0a3288e6e17.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/kaprodi/admin/surat/subjects/search'
+ */
+        searchSubjects5f083eac81bef1da2162e0a3288e6e17Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: searchSubjects5f083eac81bef1da2162e0a3288e6e17.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/kaprodi/admin/surat/subjects/search'
+ */
+        searchSubjects5f083eac81bef1da2162e0a3288e6e17Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: searchSubjects5f083eac81bef1da2162e0a3288e6e17.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    searchSubjects5f083eac81bef1da2162e0a3288e6e17.form = searchSubjects5f083eac81bef1da2162e0a3288e6e17Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/dekan/admin/surat/subjects/search'
+ */
+const searchSubjects937d78400f11c2c1af671c7917fc2221 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: searchSubjects937d78400f11c2c1af671c7917fc2221.url(options),
+    method: 'get',
+})
+
+searchSubjects937d78400f11c2c1af671c7917fc2221.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/surat/subjects/search',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/dekan/admin/surat/subjects/search'
+ */
+searchSubjects937d78400f11c2c1af671c7917fc2221.url = (options?: RouteQueryOptions) => {
+    return searchSubjects937d78400f11c2c1af671c7917fc2221.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/dekan/admin/surat/subjects/search'
+ */
+searchSubjects937d78400f11c2c1af671c7917fc2221.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: searchSubjects937d78400f11c2c1af671c7917fc2221.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/dekan/admin/surat/subjects/search'
+ */
+searchSubjects937d78400f11c2c1af671c7917fc2221.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: searchSubjects937d78400f11c2c1af671c7917fc2221.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/dekan/admin/surat/subjects/search'
+ */
+    const searchSubjects937d78400f11c2c1af671c7917fc2221Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: searchSubjects937d78400f11c2c1af671c7917fc2221.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/dekan/admin/surat/subjects/search'
+ */
+        searchSubjects937d78400f11c2c1af671c7917fc2221Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: searchSubjects937d78400f11c2c1af671c7917fc2221.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:153
+ * @route '/dekan/admin/surat/subjects/search'
+ */
+        searchSubjects937d78400f11c2c1af671c7917fc2221Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: searchSubjects937d78400f11c2c1af671c7917fc2221.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    searchSubjects937d78400f11c2c1af671c7917fc2221.form = searchSubjects937d78400f11c2c1af671c7917fc2221Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::searchSubjects, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `searchSubjects['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const searchSubjects = {
+    '/admin/surat/subjects/search': searchSubjects5a89c56f5141a7a384a5ba62957d4181,
+    '/kaprodi/admin/surat/subjects/search': searchSubjects5f083eac81bef1da2162e0a3288e6e17,
+    '/dekan/admin/surat/subjects/search': searchSubjects937d78400f11c2c1af671c7917fc2221,
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/admin/surat/preview/html'
+ */
+const previewHtml56f27c4dfef678d3647a97732bce18bc = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewHtml56f27c4dfef678d3647a97732bce18bc.url(options),
+    method: 'get',
+})
+
+previewHtml56f27c4dfef678d3647a97732bce18bc.definition = {
+    methods: ["get","head"],
+    url: '/admin/surat/preview/html',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/admin/surat/preview/html'
+ */
+previewHtml56f27c4dfef678d3647a97732bce18bc.url = (options?: RouteQueryOptions) => {
+    return previewHtml56f27c4dfef678d3647a97732bce18bc.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/admin/surat/preview/html'
+ */
+previewHtml56f27c4dfef678d3647a97732bce18bc.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewHtml56f27c4dfef678d3647a97732bce18bc.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/admin/surat/preview/html'
+ */
+previewHtml56f27c4dfef678d3647a97732bce18bc.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewHtml56f27c4dfef678d3647a97732bce18bc.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/admin/surat/preview/html'
+ */
+    const previewHtml56f27c4dfef678d3647a97732bce18bcForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewHtml56f27c4dfef678d3647a97732bce18bc.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/admin/surat/preview/html'
+ */
+        previewHtml56f27c4dfef678d3647a97732bce18bcForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewHtml56f27c4dfef678d3647a97732bce18bc.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/admin/surat/preview/html'
+ */
+        previewHtml56f27c4dfef678d3647a97732bce18bcForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewHtml56f27c4dfef678d3647a97732bce18bc.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewHtml56f27c4dfef678d3647a97732bce18bc.form = previewHtml56f27c4dfef678d3647a97732bce18bcForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/kaprodi/admin/surat/preview/html'
+ */
+const previewHtml537e5af17e919f016fb2ca8edc063c55 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewHtml537e5af17e919f016fb2ca8edc063c55.url(options),
+    method: 'get',
+})
+
+previewHtml537e5af17e919f016fb2ca8edc063c55.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/surat/preview/html',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/kaprodi/admin/surat/preview/html'
+ */
+previewHtml537e5af17e919f016fb2ca8edc063c55.url = (options?: RouteQueryOptions) => {
+    return previewHtml537e5af17e919f016fb2ca8edc063c55.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/kaprodi/admin/surat/preview/html'
+ */
+previewHtml537e5af17e919f016fb2ca8edc063c55.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewHtml537e5af17e919f016fb2ca8edc063c55.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/kaprodi/admin/surat/preview/html'
+ */
+previewHtml537e5af17e919f016fb2ca8edc063c55.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewHtml537e5af17e919f016fb2ca8edc063c55.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/kaprodi/admin/surat/preview/html'
+ */
+    const previewHtml537e5af17e919f016fb2ca8edc063c55Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewHtml537e5af17e919f016fb2ca8edc063c55.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/kaprodi/admin/surat/preview/html'
+ */
+        previewHtml537e5af17e919f016fb2ca8edc063c55Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewHtml537e5af17e919f016fb2ca8edc063c55.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/kaprodi/admin/surat/preview/html'
+ */
+        previewHtml537e5af17e919f016fb2ca8edc063c55Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewHtml537e5af17e919f016fb2ca8edc063c55.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewHtml537e5af17e919f016fb2ca8edc063c55.form = previewHtml537e5af17e919f016fb2ca8edc063c55Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/dekan/admin/surat/preview/html'
+ */
+const previewHtmla8392c760879e8b8986091432e7d7984 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewHtmla8392c760879e8b8986091432e7d7984.url(options),
+    method: 'get',
+})
+
+previewHtmla8392c760879e8b8986091432e7d7984.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/surat/preview/html',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/dekan/admin/surat/preview/html'
+ */
+previewHtmla8392c760879e8b8986091432e7d7984.url = (options?: RouteQueryOptions) => {
+    return previewHtmla8392c760879e8b8986091432e7d7984.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/dekan/admin/surat/preview/html'
+ */
+previewHtmla8392c760879e8b8986091432e7d7984.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewHtmla8392c760879e8b8986091432e7d7984.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/dekan/admin/surat/preview/html'
+ */
+previewHtmla8392c760879e8b8986091432e7d7984.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewHtmla8392c760879e8b8986091432e7d7984.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/dekan/admin/surat/preview/html'
+ */
+    const previewHtmla8392c760879e8b8986091432e7d7984Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewHtmla8392c760879e8b8986091432e7d7984.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/dekan/admin/surat/preview/html'
+ */
+        previewHtmla8392c760879e8b8986091432e7d7984Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewHtmla8392c760879e8b8986091432e7d7984.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:209
+ * @route '/dekan/admin/surat/preview/html'
+ */
+        previewHtmla8392c760879e8b8986091432e7d7984Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewHtmla8392c760879e8b8986091432e7d7984.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewHtmla8392c760879e8b8986091432e7d7984.form = previewHtmla8392c760879e8b8986091432e7d7984Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::previewHtml, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `previewHtml['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const previewHtml = {
+    '/admin/surat/preview/html': previewHtml56f27c4dfef678d3647a97732bce18bc,
+    '/kaprodi/admin/surat/preview/html': previewHtml537e5af17e919f016fb2ca8edc063c55,
+    '/dekan/admin/surat/preview/html': previewHtmla8392c760879e8b8986091432e7d7984,
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/admin/surat/preview'
+ */
+const previewPage8707cb51fadf86af9239dcc2df8a0d00 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewPage8707cb51fadf86af9239dcc2df8a0d00.url(options),
+    method: 'get',
+})
+
+previewPage8707cb51fadf86af9239dcc2df8a0d00.definition = {
     methods: ["get","head"],
     url: '/admin/surat/preview',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:97
-* @route '/admin/surat/preview'
-*/
-previewPage.url = (options?: RouteQueryOptions) => {
-    return previewPage.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/admin/surat/preview'
+ */
+previewPage8707cb51fadf86af9239dcc2df8a0d00.url = (options?: RouteQueryOptions) => {
+    return previewPage8707cb51fadf86af9239dcc2df8a0d00.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:97
-* @route '/admin/surat/preview'
-*/
-previewPage.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: previewPage.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/admin/surat/preview'
+ */
+previewPage8707cb51fadf86af9239dcc2df8a0d00.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewPage8707cb51fadf86af9239dcc2df8a0d00.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:97
-* @route '/admin/surat/preview'
-*/
-previewPage.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: previewPage.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/admin/surat/preview'
+ */
+previewPage8707cb51fadf86af9239dcc2df8a0d00.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewPage8707cb51fadf86af9239dcc2df8a0d00.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/admin/surat/preview'
+ */
+    const previewPage8707cb51fadf86af9239dcc2df8a0d00Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewPage8707cb51fadf86af9239dcc2df8a0d00.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/admin/surat/preview'
+ */
+        previewPage8707cb51fadf86af9239dcc2df8a0d00Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewPage8707cb51fadf86af9239dcc2df8a0d00.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/admin/surat/preview'
+ */
+        previewPage8707cb51fadf86af9239dcc2df8a0d00Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewPage8707cb51fadf86af9239dcc2df8a0d00.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewPage8707cb51fadf86af9239dcc2df8a0d00.form = previewPage8707cb51fadf86af9239dcc2df8a0d00Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/kaprodi/admin/surat/preview'
+ */
+const previewPaged4ff3f79f4e9a9556fd119e6f7edb755 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewPaged4ff3f79f4e9a9556fd119e6f7edb755.url(options),
+    method: 'get',
+})
+
+previewPaged4ff3f79f4e9a9556fd119e6f7edb755.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/surat/preview',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/kaprodi/admin/surat/preview'
+ */
+previewPaged4ff3f79f4e9a9556fd119e6f7edb755.url = (options?: RouteQueryOptions) => {
+    return previewPaged4ff3f79f4e9a9556fd119e6f7edb755.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/kaprodi/admin/surat/preview'
+ */
+previewPaged4ff3f79f4e9a9556fd119e6f7edb755.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewPaged4ff3f79f4e9a9556fd119e6f7edb755.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/kaprodi/admin/surat/preview'
+ */
+previewPaged4ff3f79f4e9a9556fd119e6f7edb755.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewPaged4ff3f79f4e9a9556fd119e6f7edb755.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/kaprodi/admin/surat/preview'
+ */
+    const previewPaged4ff3f79f4e9a9556fd119e6f7edb755Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewPaged4ff3f79f4e9a9556fd119e6f7edb755.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/kaprodi/admin/surat/preview'
+ */
+        previewPaged4ff3f79f4e9a9556fd119e6f7edb755Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewPaged4ff3f79f4e9a9556fd119e6f7edb755.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/kaprodi/admin/surat/preview'
+ */
+        previewPaged4ff3f79f4e9a9556fd119e6f7edb755Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewPaged4ff3f79f4e9a9556fd119e6f7edb755.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewPaged4ff3f79f4e9a9556fd119e6f7edb755.form = previewPaged4ff3f79f4e9a9556fd119e6f7edb755Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/dekan/admin/surat/preview'
+ */
+const previewPagee98480f2ca2f9b83424bc5963070a2d4 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewPagee98480f2ca2f9b83424bc5963070a2d4.url(options),
+    method: 'get',
+})
+
+previewPagee98480f2ca2f9b83424bc5963070a2d4.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/surat/preview',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/dekan/admin/surat/preview'
+ */
+previewPagee98480f2ca2f9b83424bc5963070a2d4.url = (options?: RouteQueryOptions) => {
+    return previewPagee98480f2ca2f9b83424bc5963070a2d4.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/dekan/admin/surat/preview'
+ */
+previewPagee98480f2ca2f9b83424bc5963070a2d4.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: previewPagee98480f2ca2f9b83424bc5963070a2d4.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/dekan/admin/surat/preview'
+ */
+previewPagee98480f2ca2f9b83424bc5963070a2d4.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: previewPagee98480f2ca2f9b83424bc5963070a2d4.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/dekan/admin/surat/preview'
+ */
+    const previewPagee98480f2ca2f9b83424bc5963070a2d4Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewPagee98480f2ca2f9b83424bc5963070a2d4.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/dekan/admin/surat/preview'
+ */
+        previewPagee98480f2ca2f9b83424bc5963070a2d4Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewPagee98480f2ca2f9b83424bc5963070a2d4.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::previewPage
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:193
+ * @route '/dekan/admin/surat/preview'
+ */
+        previewPagee98480f2ca2f9b83424bc5963070a2d4Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewPagee98480f2ca2f9b83424bc5963070a2d4.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewPagee98480f2ca2f9b83424bc5963070a2d4.form = previewPagee98480f2ca2f9b83424bc5963070a2d4Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::previewPage, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `previewPage['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const previewPage = {
+    '/admin/surat/preview': previewPage8707cb51fadf86af9239dcc2df8a0d00,
+    '/kaprodi/admin/surat/preview': previewPaged4ff3f79f4e9a9556fd119e6f7edb755,
+    '/dekan/admin/surat/preview': previewPagee98480f2ca2f9b83424bc5963070a2d4,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:85
-* @route '/admin/surat/preview'
-*/
-export const preview = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: preview.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/admin/surat/preview'
+ */
+const preview8707cb51fadf86af9239dcc2df8a0d00 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: preview8707cb51fadf86af9239dcc2df8a0d00.url(options),
     method: 'post',
 })
 
-preview.definition = {
+preview8707cb51fadf86af9239dcc2df8a0d00.definition = {
     methods: ["post"],
     url: '/admin/surat/preview',
 } satisfies RouteDefinition<["post"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:85
-* @route '/admin/surat/preview'
-*/
-preview.url = (options?: RouteQueryOptions) => {
-    return preview.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/admin/surat/preview'
+ */
+preview8707cb51fadf86af9239dcc2df8a0d00.url = (options?: RouteQueryOptions) => {
+    return preview8707cb51fadf86af9239dcc2df8a0d00.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:85
-* @route '/admin/surat/preview'
-*/
-preview.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: preview.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/admin/surat/preview'
+ */
+preview8707cb51fadf86af9239dcc2df8a0d00.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: preview8707cb51fadf86af9239dcc2df8a0d00.url(options),
     method: 'post',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/admin/surat/preview'
+ */
+    const preview8707cb51fadf86af9239dcc2df8a0d00Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: preview8707cb51fadf86af9239dcc2df8a0d00.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/admin/surat/preview'
+ */
+        preview8707cb51fadf86af9239dcc2df8a0d00Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: preview8707cb51fadf86af9239dcc2df8a0d00.url(options),
+            method: 'post',
+        })
+    
+    preview8707cb51fadf86af9239dcc2df8a0d00.form = preview8707cb51fadf86af9239dcc2df8a0d00Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/kaprodi/admin/surat/preview'
+ */
+const previewd4ff3f79f4e9a9556fd119e6f7edb755 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: previewd4ff3f79f4e9a9556fd119e6f7edb755.url(options),
+    method: 'post',
+})
+
+previewd4ff3f79f4e9a9556fd119e6f7edb755.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/surat/preview',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/kaprodi/admin/surat/preview'
+ */
+previewd4ff3f79f4e9a9556fd119e6f7edb755.url = (options?: RouteQueryOptions) => {
+    return previewd4ff3f79f4e9a9556fd119e6f7edb755.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/kaprodi/admin/surat/preview'
+ */
+previewd4ff3f79f4e9a9556fd119e6f7edb755.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: previewd4ff3f79f4e9a9556fd119e6f7edb755.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/kaprodi/admin/surat/preview'
+ */
+    const previewd4ff3f79f4e9a9556fd119e6f7edb755Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: previewd4ff3f79f4e9a9556fd119e6f7edb755.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/kaprodi/admin/surat/preview'
+ */
+        previewd4ff3f79f4e9a9556fd119e6f7edb755Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: previewd4ff3f79f4e9a9556fd119e6f7edb755.url(options),
+            method: 'post',
+        })
+    
+    previewd4ff3f79f4e9a9556fd119e6f7edb755.form = previewd4ff3f79f4e9a9556fd119e6f7edb755Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/dekan/admin/surat/preview'
+ */
+const previewe98480f2ca2f9b83424bc5963070a2d4 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: previewe98480f2ca2f9b83424bc5963070a2d4.url(options),
+    method: 'post',
+})
+
+previewe98480f2ca2f9b83424bc5963070a2d4.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/surat/preview',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/dekan/admin/surat/preview'
+ */
+previewe98480f2ca2f9b83424bc5963070a2d4.url = (options?: RouteQueryOptions) => {
+    return previewe98480f2ca2f9b83424bc5963070a2d4.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/dekan/admin/surat/preview'
+ */
+previewe98480f2ca2f9b83424bc5963070a2d4.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: previewe98480f2ca2f9b83424bc5963070a2d4.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/dekan/admin/surat/preview'
+ */
+    const previewe98480f2ca2f9b83424bc5963070a2d4Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: previewe98480f2ca2f9b83424bc5963070a2d4.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::preview
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:179
+ * @route '/dekan/admin/surat/preview'
+ */
+        previewe98480f2ca2f9b83424bc5963070a2d4Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: previewe98480f2ca2f9b83424bc5963070a2d4.url(options),
+            method: 'post',
+        })
+    
+    previewe98480f2ca2f9b83424bc5963070a2d4.form = previewe98480f2ca2f9b83424bc5963070a2d4Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::preview, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `preview['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const preview = {
+    '/admin/surat/preview': preview8707cb51fadf86af9239dcc2df8a0d00,
+    '/kaprodi/admin/surat/preview': previewd4ff3f79f4e9a9556fd119e6f7edb755,
+    '/dekan/admin/surat/preview': previewe98480f2ca2f9b83424bc5963070a2d4,
+}
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::store
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:161
-* @route '/admin/surat/store'
-*/
-export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: store.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/admin/surat/store'
+ */
+const storeba4f8621df23c4a11d93b52f7fdc9b17 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: storeba4f8621df23c4a11d93b52f7fdc9b17.url(options),
     method: 'post',
 })
 
-store.definition = {
+storeba4f8621df23c4a11d93b52f7fdc9b17.definition = {
     methods: ["post"],
     url: '/admin/surat/store',
 } satisfies RouteDefinition<["post"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::store
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:161
-* @route '/admin/surat/store'
-*/
-store.url = (options?: RouteQueryOptions) => {
-    return store.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/admin/surat/store'
+ */
+storeba4f8621df23c4a11d93b52f7fdc9b17.url = (options?: RouteQueryOptions) => {
+    return storeba4f8621df23c4a11d93b52f7fdc9b17.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::store
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:161
-* @route '/admin/surat/store'
-*/
-store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: store.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/admin/surat/store'
+ */
+storeba4f8621df23c4a11d93b52f7fdc9b17.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: storeba4f8621df23c4a11d93b52f7fdc9b17.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/admin/surat/store'
+ */
+    const storeba4f8621df23c4a11d93b52f7fdc9b17Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: storeba4f8621df23c4a11d93b52f7fdc9b17.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/admin/surat/store'
+ */
+        storeba4f8621df23c4a11d93b52f7fdc9b17Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: storeba4f8621df23c4a11d93b52f7fdc9b17.url(options),
+            method: 'post',
+        })
+    
+    storeba4f8621df23c4a11d93b52f7fdc9b17.form = storeba4f8621df23c4a11d93b52f7fdc9b17Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/kaprodi/admin/surat/store'
+ */
+const storefcaf9c90326584d9150a59d639a726b8 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: storefcaf9c90326584d9150a59d639a726b8.url(options),
+    method: 'post',
+})
+
+storefcaf9c90326584d9150a59d639a726b8.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/surat/store',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/kaprodi/admin/surat/store'
+ */
+storefcaf9c90326584d9150a59d639a726b8.url = (options?: RouteQueryOptions) => {
+    return storefcaf9c90326584d9150a59d639a726b8.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/kaprodi/admin/surat/store'
+ */
+storefcaf9c90326584d9150a59d639a726b8.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: storefcaf9c90326584d9150a59d639a726b8.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/kaprodi/admin/surat/store'
+ */
+    const storefcaf9c90326584d9150a59d639a726b8Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: storefcaf9c90326584d9150a59d639a726b8.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/kaprodi/admin/surat/store'
+ */
+        storefcaf9c90326584d9150a59d639a726b8Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: storefcaf9c90326584d9150a59d639a726b8.url(options),
+            method: 'post',
+        })
+    
+    storefcaf9c90326584d9150a59d639a726b8.form = storefcaf9c90326584d9150a59d639a726b8Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/dekan/admin/surat/store'
+ */
+const stored9e0eeca32b83c966747d6650e6a3375 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: stored9e0eeca32b83c966747d6650e6a3375.url(options),
+    method: 'post',
+})
+
+stored9e0eeca32b83c966747d6650e6a3375.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/surat/store',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/dekan/admin/surat/store'
+ */
+stored9e0eeca32b83c966747d6650e6a3375.url = (options?: RouteQueryOptions) => {
+    return stored9e0eeca32b83c966747d6650e6a3375.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/dekan/admin/surat/store'
+ */
+stored9e0eeca32b83c966747d6650e6a3375.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: stored9e0eeca32b83c966747d6650e6a3375.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/dekan/admin/surat/store'
+ */
+    const stored9e0eeca32b83c966747d6650e6a3375Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: stored9e0eeca32b83c966747d6650e6a3375.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::store
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:222
+ * @route '/dekan/admin/surat/store'
+ */
+        stored9e0eeca32b83c966747d6650e6a3375Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: stored9e0eeca32b83c966747d6650e6a3375.url(options),
+            method: 'post',
+        })
+    
+    stored9e0eeca32b83c966747d6650e6a3375.form = stored9e0eeca32b83c966747d6650e6a3375Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::store, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `store['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const store = {
+    '/admin/surat/store': storeba4f8621df23c4a11d93b52f7fdc9b17,
+    '/kaprodi/admin/surat/store': storefcaf9c90326584d9150a59d639a726b8,
+    '/dekan/admin/surat/store': stored9e0eeca32b83c966747d6650e6a3375,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:199
-* @route '/admin/surat/{id}/edit'
-*/
-export const edit = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: edit.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/admin/surat/{id}/edit'
+ */
+const edit75856c3816cc3442df74e71499cfe47f = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: edit75856c3816cc3442df74e71499cfe47f.url(args, options),
     method: 'get',
 })
 
-edit.definition = {
+edit75856c3816cc3442df74e71499cfe47f.definition = {
     methods: ["get","head"],
     url: '/admin/surat/{id}/edit',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:199
-* @route '/admin/surat/{id}/edit'
-*/
-edit.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/admin/surat/{id}/edit'
+ */
+edit75856c3816cc3442df74e71499cfe47f.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
-    return edit.definition.url
+    return edit75856c3816cc3442df74e71499cfe47f.definition.url
             .replace('{id}', parsedArgs.id.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:199
-* @route '/admin/surat/{id}/edit'
-*/
-edit.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: edit.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/admin/surat/{id}/edit'
+ */
+edit75856c3816cc3442df74e71499cfe47f.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: edit75856c3816cc3442df74e71499cfe47f.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:199
-* @route '/admin/surat/{id}/edit'
-*/
-edit.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: edit.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/admin/surat/{id}/edit'
+ */
+edit75856c3816cc3442df74e71499cfe47f.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: edit75856c3816cc3442df74e71499cfe47f.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/admin/surat/{id}/edit'
+ */
+    const edit75856c3816cc3442df74e71499cfe47fForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: edit75856c3816cc3442df74e71499cfe47f.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/admin/surat/{id}/edit'
+ */
+        edit75856c3816cc3442df74e71499cfe47fForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit75856c3816cc3442df74e71499cfe47f.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/admin/surat/{id}/edit'
+ */
+        edit75856c3816cc3442df74e71499cfe47fForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit75856c3816cc3442df74e71499cfe47f.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    edit75856c3816cc3442df74e71499cfe47f.form = edit75856c3816cc3442df74e71499cfe47fForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/kaprodi/admin/surat/{id}/edit'
+ */
+const edit8c888f2614757efb48e090fa9b8ce32e = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: edit8c888f2614757efb48e090fa9b8ce32e.url(args, options),
+    method: 'get',
+})
+
+edit8c888f2614757efb48e090fa9b8ce32e.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/surat/{id}/edit',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/kaprodi/admin/surat/{id}/edit'
+ */
+edit8c888f2614757efb48e090fa9b8ce32e.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return edit8c888f2614757efb48e090fa9b8ce32e.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/kaprodi/admin/surat/{id}/edit'
+ */
+edit8c888f2614757efb48e090fa9b8ce32e.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: edit8c888f2614757efb48e090fa9b8ce32e.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/kaprodi/admin/surat/{id}/edit'
+ */
+edit8c888f2614757efb48e090fa9b8ce32e.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: edit8c888f2614757efb48e090fa9b8ce32e.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/kaprodi/admin/surat/{id}/edit'
+ */
+    const edit8c888f2614757efb48e090fa9b8ce32eForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: edit8c888f2614757efb48e090fa9b8ce32e.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/kaprodi/admin/surat/{id}/edit'
+ */
+        edit8c888f2614757efb48e090fa9b8ce32eForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit8c888f2614757efb48e090fa9b8ce32e.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/kaprodi/admin/surat/{id}/edit'
+ */
+        edit8c888f2614757efb48e090fa9b8ce32eForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit8c888f2614757efb48e090fa9b8ce32e.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    edit8c888f2614757efb48e090fa9b8ce32e.form = edit8c888f2614757efb48e090fa9b8ce32eForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/dekan/admin/surat/{id}/edit'
+ */
+const editcb8817cddfc774bcfd57bbf0190c9f18 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: editcb8817cddfc774bcfd57bbf0190c9f18.url(args, options),
+    method: 'get',
+})
+
+editcb8817cddfc774bcfd57bbf0190c9f18.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/surat/{id}/edit',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/dekan/admin/surat/{id}/edit'
+ */
+editcb8817cddfc774bcfd57bbf0190c9f18.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return editcb8817cddfc774bcfd57bbf0190c9f18.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/dekan/admin/surat/{id}/edit'
+ */
+editcb8817cddfc774bcfd57bbf0190c9f18.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: editcb8817cddfc774bcfd57bbf0190c9f18.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/dekan/admin/surat/{id}/edit'
+ */
+editcb8817cddfc774bcfd57bbf0190c9f18.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: editcb8817cddfc774bcfd57bbf0190c9f18.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/dekan/admin/surat/{id}/edit'
+ */
+    const editcb8817cddfc774bcfd57bbf0190c9f18Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: editcb8817cddfc774bcfd57bbf0190c9f18.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/dekan/admin/surat/{id}/edit'
+ */
+        editcb8817cddfc774bcfd57bbf0190c9f18Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: editcb8817cddfc774bcfd57bbf0190c9f18.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::edit
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:263
+ * @route '/dekan/admin/surat/{id}/edit'
+ */
+        editcb8817cddfc774bcfd57bbf0190c9f18Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: editcb8817cddfc774bcfd57bbf0190c9f18.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    editcb8817cddfc774bcfd57bbf0190c9f18.form = editcb8817cddfc774bcfd57bbf0190c9f18Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::edit, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `edit['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const edit = {
+    '/admin/surat/{id}/edit': edit75856c3816cc3442df74e71499cfe47f,
+    '/kaprodi/admin/surat/{id}/edit': edit8c888f2614757efb48e090fa9b8ce32e,
+    '/dekan/admin/surat/{id}/edit': editcb8817cddfc774bcfd57bbf0190c9f18,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::update
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:237
-* @route '/admin/surat/{id}'
-*/
-export const update = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
-    url: update.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/admin/surat/{id}'
+ */
+const updatecaa2593158145898f04ae0567d4630f4 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: updatecaa2593158145898f04ae0567d4630f4.url(args, options),
     method: 'patch',
 })
 
-update.definition = {
+updatecaa2593158145898f04ae0567d4630f4.definition = {
     methods: ["patch"],
     url: '/admin/surat/{id}',
 } satisfies RouteDefinition<["patch"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::update
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:237
-* @route '/admin/surat/{id}'
-*/
-update.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/admin/surat/{id}'
+ */
+updatecaa2593158145898f04ae0567d4630f4.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
-    return update.definition.url
+    return updatecaa2593158145898f04ae0567d4630f4.definition.url
             .replace('{id}', parsedArgs.id.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterController::update
-* @see app/Modules/Fast/Controllers/Admin/LetterController.php:237
-* @route '/admin/surat/{id}'
-*/
-update.patch = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
-    url: update.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/admin/surat/{id}'
+ */
+updatecaa2593158145898f04ae0567d4630f4.patch = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: updatecaa2593158145898f04ae0567d4630f4.url(args, options),
     method: 'patch',
 })
 
-const LetterController = { generate, create, selectType, form, previewPage, preview, store, edit, update }
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/admin/surat/{id}'
+ */
+    const updatecaa2593158145898f04ae0567d4630f4Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: updatecaa2593158145898f04ae0567d4630f4.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PATCH',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/admin/surat/{id}'
+ */
+        updatecaa2593158145898f04ae0567d4630f4Form.patch = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: updatecaa2593158145898f04ae0567d4630f4.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    updatecaa2593158145898f04ae0567d4630f4.form = updatecaa2593158145898f04ae0567d4630f4Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+const update927fcee68fb401f2468c1f9e0dccf577 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: update927fcee68fb401f2468c1f9e0dccf577.url(args, options),
+    method: 'patch',
+})
+
+update927fcee68fb401f2468c1f9e0dccf577.definition = {
+    methods: ["patch"],
+    url: '/kaprodi/admin/surat/{id}',
+} satisfies RouteDefinition<["patch"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+update927fcee68fb401f2468c1f9e0dccf577.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return update927fcee68fb401f2468c1f9e0dccf577.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+update927fcee68fb401f2468c1f9e0dccf577.patch = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: update927fcee68fb401f2468c1f9e0dccf577.url(args, options),
+    method: 'patch',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+    const update927fcee68fb401f2468c1f9e0dccf577Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update927fcee68fb401f2468c1f9e0dccf577.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PATCH',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/kaprodi/admin/surat/{id}'
+ */
+        update927fcee68fb401f2468c1f9e0dccf577Form.patch = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update927fcee68fb401f2468c1f9e0dccf577.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update927fcee68fb401f2468c1f9e0dccf577.form = update927fcee68fb401f2468c1f9e0dccf577Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/dekan/admin/surat/{id}'
+ */
+const update02a2db8a6087a1edeb8a0ca8e2e42db2 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: update02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, options),
+    method: 'patch',
+})
+
+update02a2db8a6087a1edeb8a0ca8e2e42db2.definition = {
+    methods: ["patch"],
+    url: '/dekan/admin/surat/{id}',
+} satisfies RouteDefinition<["patch"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/dekan/admin/surat/{id}'
+ */
+update02a2db8a6087a1edeb8a0ca8e2e42db2.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { id: args }
+    }
+
+    
+    if (Array.isArray(args)) {
+        args = {
+                    id: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        id: args.id,
+                }
+
+    return update02a2db8a6087a1edeb8a0ca8e2e42db2.definition.url
+            .replace('{id}', parsedArgs.id.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/dekan/admin/surat/{id}'
+ */
+update02a2db8a6087a1edeb8a0ca8e2e42db2.patch = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: update02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, options),
+    method: 'patch',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/dekan/admin/surat/{id}'
+ */
+    const update02a2db8a6087a1edeb8a0ca8e2e42db2Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PATCH',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterController::update
+ * @see app/Modules/Fast/Controllers/Admin/LetterController.php:315
+ * @route '/dekan/admin/surat/{id}'
+ */
+        update02a2db8a6087a1edeb8a0ca8e2e42db2Form.patch = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update02a2db8a6087a1edeb8a0ca8e2e42db2.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update02a2db8a6087a1edeb8a0ca8e2e42db2.form = update02a2db8a6087a1edeb8a0ca8e2e42db2Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterController::update, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `update['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const update = {
+    '/admin/surat/{id}': updatecaa2593158145898f04ae0567d4630f4,
+    '/kaprodi/admin/surat/{id}': update927fcee68fb401f2468c1f9e0dccf577,
+    '/dekan/admin/surat/{id}': update02a2db8a6087a1edeb8a0ca8e2e42db2,
+}
+
+const LetterController = { generate, create, selectType, form, searchSubjects, previewHtml, previewPage, preview, store, edit, update }
 
 export default LetterController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/LetterIndexController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/LetterIndexController.ts
@@ -1,47 +1,249 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
-* @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:16
-* @route '/admin/surat'
-*/
-export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/admin/surat'
+ */
+const indexb6e06a6546a9d86589b4a3bd0d762019 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexb6e06a6546a9d86589b4a3bd0d762019.url(options),
     method: 'get',
 })
 
-index.definition = {
+indexb6e06a6546a9d86589b4a3bd0d762019.definition = {
     methods: ["get","head"],
     url: '/admin/surat',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
-* @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:16
-* @route '/admin/surat'
-*/
-index.url = (options?: RouteQueryOptions) => {
-    return index.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/admin/surat'
+ */
+indexb6e06a6546a9d86589b4a3bd0d762019.url = (options?: RouteQueryOptions) => {
+    return indexb6e06a6546a9d86589b4a3bd0d762019.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
-* @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:16
-* @route '/admin/surat'
-*/
-index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/admin/surat'
+ */
+indexb6e06a6546a9d86589b4a3bd0d762019.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexb6e06a6546a9d86589b4a3bd0d762019.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/admin/surat'
+ */
+indexb6e06a6546a9d86589b4a3bd0d762019.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexb6e06a6546a9d86589b4a3bd0d762019.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/admin/surat'
+ */
+    const indexb6e06a6546a9d86589b4a3bd0d762019Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexb6e06a6546a9d86589b4a3bd0d762019.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/admin/surat'
+ */
+        indexb6e06a6546a9d86589b4a3bd0d762019Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexb6e06a6546a9d86589b4a3bd0d762019.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/admin/surat'
+ */
+        indexb6e06a6546a9d86589b4a3bd0d762019Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexb6e06a6546a9d86589b4a3bd0d762019.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexb6e06a6546a9d86589b4a3bd0d762019.form = indexb6e06a6546a9d86589b4a3bd0d762019Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/kaprodi/admin/surat'
+ */
+const indexa7b3ecf96d6799e3f82b703d51393ef2 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexa7b3ecf96d6799e3f82b703d51393ef2.url(options),
     method: 'get',
 })
 
+indexa7b3ecf96d6799e3f82b703d51393ef2.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/surat',
+} satisfies RouteDefinition<["get","head"]>
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
-* @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:16
-* @route '/admin/surat'
-*/
-index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/kaprodi/admin/surat'
+ */
+indexa7b3ecf96d6799e3f82b703d51393ef2.url = (options?: RouteQueryOptions) => {
+    return indexa7b3ecf96d6799e3f82b703d51393ef2.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/kaprodi/admin/surat'
+ */
+indexa7b3ecf96d6799e3f82b703d51393ef2.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexa7b3ecf96d6799e3f82b703d51393ef2.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/kaprodi/admin/surat'
+ */
+indexa7b3ecf96d6799e3f82b703d51393ef2.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexa7b3ecf96d6799e3f82b703d51393ef2.url(options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/kaprodi/admin/surat'
+ */
+    const indexa7b3ecf96d6799e3f82b703d51393ef2Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexa7b3ecf96d6799e3f82b703d51393ef2.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/kaprodi/admin/surat'
+ */
+        indexa7b3ecf96d6799e3f82b703d51393ef2Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexa7b3ecf96d6799e3f82b703d51393ef2.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/kaprodi/admin/surat'
+ */
+        indexa7b3ecf96d6799e3f82b703d51393ef2Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexa7b3ecf96d6799e3f82b703d51393ef2.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexa7b3ecf96d6799e3f82b703d51393ef2.form = indexa7b3ecf96d6799e3f82b703d51393ef2Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/dekan/admin/surat'
+ */
+const indexd1d46f125ca85668855e663ec8e12f75 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexd1d46f125ca85668855e663ec8e12f75.url(options),
+    method: 'get',
+})
+
+indexd1d46f125ca85668855e663ec8e12f75.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/surat',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/dekan/admin/surat'
+ */
+indexd1d46f125ca85668855e663ec8e12f75.url = (options?: RouteQueryOptions) => {
+    return indexd1d46f125ca85668855e663ec8e12f75.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/dekan/admin/surat'
+ */
+indexd1d46f125ca85668855e663ec8e12f75.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexd1d46f125ca85668855e663ec8e12f75.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/dekan/admin/surat'
+ */
+indexd1d46f125ca85668855e663ec8e12f75.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexd1d46f125ca85668855e663ec8e12f75.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/dekan/admin/surat'
+ */
+    const indexd1d46f125ca85668855e663ec8e12f75Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexd1d46f125ca85668855e663ec8e12f75.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/dekan/admin/surat'
+ */
+        indexd1d46f125ca85668855e663ec8e12f75Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexd1d46f125ca85668855e663ec8e12f75.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\LetterIndexController::index
+ * @see app/Modules/Fast/Controllers/Admin/LetterIndexController.php:17
+ * @route '/dekan/admin/surat'
+ */
+        indexd1d46f125ca85668855e663ec8e12f75Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexd1d46f125ca85668855e663ec8e12f75.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexd1d46f125ca85668855e663ec8e12f75.form = indexd1d46f125ca85668855e663ec8e12f75Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\LetterIndexController::index, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `index['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const index = {
+    '/admin/surat': indexb6e06a6546a9d86589b4a3bd0d762019,
+    '/kaprodi/admin/surat': indexa7b3ecf96d6799e3f82b703d51393ef2,
+    '/dekan/admin/surat': indexd1d46f125ca85668855e663ec8e12f75,
+}
 
 const LetterIndexController = { index }
 

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/QrManageController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/QrManageController.ts
@@ -1,47 +1,249 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
-* @see app/Modules/Fast/Controllers/Admin/QrManageController.php:18
-* @route '/admin/qr'
-*/
-export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/admin/qr'
+ */
+const index4c30f5087ac3163e9a371a2d63a361c7 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index4c30f5087ac3163e9a371a2d63a361c7.url(options),
     method: 'get',
 })
 
-index.definition = {
+index4c30f5087ac3163e9a371a2d63a361c7.definition = {
     methods: ["get","head"],
     url: '/admin/qr',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
-* @see app/Modules/Fast/Controllers/Admin/QrManageController.php:18
-* @route '/admin/qr'
-*/
-index.url = (options?: RouteQueryOptions) => {
-    return index.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/admin/qr'
+ */
+index4c30f5087ac3163e9a371a2d63a361c7.url = (options?: RouteQueryOptions) => {
+    return index4c30f5087ac3163e9a371a2d63a361c7.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
-* @see app/Modules/Fast/Controllers/Admin/QrManageController.php:18
-* @route '/admin/qr'
-*/
-index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/admin/qr'
+ */
+index4c30f5087ac3163e9a371a2d63a361c7.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index4c30f5087ac3163e9a371a2d63a361c7.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/admin/qr'
+ */
+index4c30f5087ac3163e9a371a2d63a361c7.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index4c30f5087ac3163e9a371a2d63a361c7.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/admin/qr'
+ */
+    const index4c30f5087ac3163e9a371a2d63a361c7Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index4c30f5087ac3163e9a371a2d63a361c7.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/admin/qr'
+ */
+        index4c30f5087ac3163e9a371a2d63a361c7Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index4c30f5087ac3163e9a371a2d63a361c7.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/admin/qr'
+ */
+        index4c30f5087ac3163e9a371a2d63a361c7Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index4c30f5087ac3163e9a371a2d63a361c7.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index4c30f5087ac3163e9a371a2d63a361c7.form = index4c30f5087ac3163e9a371a2d63a361c7Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/kaprodi/admin/qr'
+ */
+const indexf01271985537308e0e3d76108f698bb1 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexf01271985537308e0e3d76108f698bb1.url(options),
     method: 'get',
 })
 
+indexf01271985537308e0e3d76108f698bb1.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/qr',
+} satisfies RouteDefinition<["get","head"]>
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
-* @see app/Modules/Fast/Controllers/Admin/QrManageController.php:18
-* @route '/admin/qr'
-*/
-index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/kaprodi/admin/qr'
+ */
+indexf01271985537308e0e3d76108f698bb1.url = (options?: RouteQueryOptions) => {
+    return indexf01271985537308e0e3d76108f698bb1.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/kaprodi/admin/qr'
+ */
+indexf01271985537308e0e3d76108f698bb1.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexf01271985537308e0e3d76108f698bb1.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/kaprodi/admin/qr'
+ */
+indexf01271985537308e0e3d76108f698bb1.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexf01271985537308e0e3d76108f698bb1.url(options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/kaprodi/admin/qr'
+ */
+    const indexf01271985537308e0e3d76108f698bb1Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexf01271985537308e0e3d76108f698bb1.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/kaprodi/admin/qr'
+ */
+        indexf01271985537308e0e3d76108f698bb1Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexf01271985537308e0e3d76108f698bb1.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/kaprodi/admin/qr'
+ */
+        indexf01271985537308e0e3d76108f698bb1Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexf01271985537308e0e3d76108f698bb1.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexf01271985537308e0e3d76108f698bb1.form = indexf01271985537308e0e3d76108f698bb1Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/dekan/admin/qr'
+ */
+const indexd9576a753905748ddd0358631b11248a = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexd9576a753905748ddd0358631b11248a.url(options),
+    method: 'get',
+})
+
+indexd9576a753905748ddd0358631b11248a.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/qr',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/dekan/admin/qr'
+ */
+indexd9576a753905748ddd0358631b11248a.url = (options?: RouteQueryOptions) => {
+    return indexd9576a753905748ddd0358631b11248a.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/dekan/admin/qr'
+ */
+indexd9576a753905748ddd0358631b11248a.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexd9576a753905748ddd0358631b11248a.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/dekan/admin/qr'
+ */
+indexd9576a753905748ddd0358631b11248a.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexd9576a753905748ddd0358631b11248a.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/dekan/admin/qr'
+ */
+    const indexd9576a753905748ddd0358631b11248aForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexd9576a753905748ddd0358631b11248a.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/dekan/admin/qr'
+ */
+        indexd9576a753905748ddd0358631b11248aForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexd9576a753905748ddd0358631b11248a.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\QrManageController::index
+ * @see app/Modules/Fast/Controllers/Admin/QrManageController.php:17
+ * @route '/dekan/admin/qr'
+ */
+        indexd9576a753905748ddd0358631b11248aForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexd9576a753905748ddd0358631b11248a.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexd9576a753905748ddd0358631b11248a.form = indexd9576a753905748ddd0358631b11248aForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\QrManageController::index, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `index['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const index = {
+    '/admin/qr': index4c30f5087ac3163e9a371a2d63a361c7,
+    '/kaprodi/admin/qr': indexf01271985537308e0e3d76108f698bb1,
+    '/dekan/admin/qr': indexd9576a753905748ddd0358631b11248a,
+}
 
 const QrManageController = { index }
 

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/TemplateController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/TemplateController.ts
@@ -1,381 +1,1830 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
-* @route '/admin/templates'
-*/
-export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/admin/templates'
+ */
+const indexd5705b7847a1ea5930840f23087f91b5 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexd5705b7847a1ea5930840f23087f91b5.url(options),
     method: 'get',
 })
 
-index.definition = {
+indexd5705b7847a1ea5930840f23087f91b5.definition = {
     methods: ["get","head"],
     url: '/admin/templates',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
-* @route '/admin/templates'
-*/
-index.url = (options?: RouteQueryOptions) => {
-    return index.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/admin/templates'
+ */
+indexd5705b7847a1ea5930840f23087f91b5.url = (options?: RouteQueryOptions) => {
+    return indexd5705b7847a1ea5930840f23087f91b5.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
-* @route '/admin/templates'
-*/
-index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/admin/templates'
+ */
+indexd5705b7847a1ea5930840f23087f91b5.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: indexd5705b7847a1ea5930840f23087f91b5.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
-* @route '/admin/templates'
-*/
-index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: index.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/admin/templates'
+ */
+indexd5705b7847a1ea5930840f23087f91b5.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: indexd5705b7847a1ea5930840f23087f91b5.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/admin/templates'
+ */
+    const indexd5705b7847a1ea5930840f23087f91b5Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexd5705b7847a1ea5930840f23087f91b5.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/admin/templates'
+ */
+        indexd5705b7847a1ea5930840f23087f91b5Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexd5705b7847a1ea5930840f23087f91b5.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/admin/templates'
+ */
+        indexd5705b7847a1ea5930840f23087f91b5Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexd5705b7847a1ea5930840f23087f91b5.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexd5705b7847a1ea5930840f23087f91b5.form = indexd5705b7847a1ea5930840f23087f91b5Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/kaprodi/admin/templates'
+ */
+const index957b1c8b41d8f17421652f676b6684f7 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index957b1c8b41d8f17421652f676b6684f7.url(options),
+    method: 'get',
+})
+
+index957b1c8b41d8f17421652f676b6684f7.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/templates',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/kaprodi/admin/templates'
+ */
+index957b1c8b41d8f17421652f676b6684f7.url = (options?: RouteQueryOptions) => {
+    return index957b1c8b41d8f17421652f676b6684f7.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/kaprodi/admin/templates'
+ */
+index957b1c8b41d8f17421652f676b6684f7.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index957b1c8b41d8f17421652f676b6684f7.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/kaprodi/admin/templates'
+ */
+index957b1c8b41d8f17421652f676b6684f7.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index957b1c8b41d8f17421652f676b6684f7.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/kaprodi/admin/templates'
+ */
+    const index957b1c8b41d8f17421652f676b6684f7Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index957b1c8b41d8f17421652f676b6684f7.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/kaprodi/admin/templates'
+ */
+        index957b1c8b41d8f17421652f676b6684f7Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index957b1c8b41d8f17421652f676b6684f7.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/kaprodi/admin/templates'
+ */
+        index957b1c8b41d8f17421652f676b6684f7Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index957b1c8b41d8f17421652f676b6684f7.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index957b1c8b41d8f17421652f676b6684f7.form = index957b1c8b41d8f17421652f676b6684f7Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/dekan/admin/templates'
+ */
+const index8d93e22505e0269c341ad40364c118ce = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index8d93e22505e0269c341ad40364c118ce.url(options),
+    method: 'get',
+})
+
+index8d93e22505e0269c341ad40364c118ce.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/templates',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/dekan/admin/templates'
+ */
+index8d93e22505e0269c341ad40364c118ce.url = (options?: RouteQueryOptions) => {
+    return index8d93e22505e0269c341ad40364c118ce.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/dekan/admin/templates'
+ */
+index8d93e22505e0269c341ad40364c118ce.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: index8d93e22505e0269c341ad40364c118ce.url(options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/dekan/admin/templates'
+ */
+index8d93e22505e0269c341ad40364c118ce.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: index8d93e22505e0269c341ad40364c118ce.url(options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/dekan/admin/templates'
+ */
+    const index8d93e22505e0269c341ad40364c118ceForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index8d93e22505e0269c341ad40364c118ce.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/dekan/admin/templates'
+ */
+        index8d93e22505e0269c341ad40364c118ceForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index8d93e22505e0269c341ad40364c118ce.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::index
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:20
+ * @route '/dekan/admin/templates'
+ */
+        index8d93e22505e0269c341ad40364c118ceForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index8d93e22505e0269c341ad40364c118ce.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index8d93e22505e0269c341ad40364c118ce.form = index8d93e22505e0269c341ad40364c118ceForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\TemplateController::index, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `index['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const index = {
+    '/admin/templates': indexd5705b7847a1ea5930840f23087f91b5,
+    '/kaprodi/admin/templates': index957b1c8b41d8f17421652f676b6684f7,
+    '/dekan/admin/templates': index8d93e22505e0269c341ad40364c118ce,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:25
-* @route '/admin/templates'
-*/
-export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: store.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/admin/templates'
+ */
+const stored5705b7847a1ea5930840f23087f91b5 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: stored5705b7847a1ea5930840f23087f91b5.url(options),
     method: 'post',
 })
 
-store.definition = {
+stored5705b7847a1ea5930840f23087f91b5.definition = {
     methods: ["post"],
     url: '/admin/templates',
 } satisfies RouteDefinition<["post"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:25
-* @route '/admin/templates'
-*/
-store.url = (options?: RouteQueryOptions) => {
-    return store.definition.url + queryParams(options)
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/admin/templates'
+ */
+stored5705b7847a1ea5930840f23087f91b5.url = (options?: RouteQueryOptions) => {
+    return stored5705b7847a1ea5930840f23087f91b5.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:25
-* @route '/admin/templates'
-*/
-store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: store.url(options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/admin/templates'
+ */
+stored5705b7847a1ea5930840f23087f91b5.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: stored5705b7847a1ea5930840f23087f91b5.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/admin/templates'
+ */
+    const stored5705b7847a1ea5930840f23087f91b5Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: stored5705b7847a1ea5930840f23087f91b5.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/admin/templates'
+ */
+        stored5705b7847a1ea5930840f23087f91b5Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: stored5705b7847a1ea5930840f23087f91b5.url(options),
+            method: 'post',
+        })
+    
+    stored5705b7847a1ea5930840f23087f91b5.form = stored5705b7847a1ea5930840f23087f91b5Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/kaprodi/admin/templates'
+ */
+const store957b1c8b41d8f17421652f676b6684f7 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store957b1c8b41d8f17421652f676b6684f7.url(options),
+    method: 'post',
+})
+
+store957b1c8b41d8f17421652f676b6684f7.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/templates',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/kaprodi/admin/templates'
+ */
+store957b1c8b41d8f17421652f676b6684f7.url = (options?: RouteQueryOptions) => {
+    return store957b1c8b41d8f17421652f676b6684f7.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/kaprodi/admin/templates'
+ */
+store957b1c8b41d8f17421652f676b6684f7.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store957b1c8b41d8f17421652f676b6684f7.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/kaprodi/admin/templates'
+ */
+    const store957b1c8b41d8f17421652f676b6684f7Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store957b1c8b41d8f17421652f676b6684f7.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/kaprodi/admin/templates'
+ */
+        store957b1c8b41d8f17421652f676b6684f7Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store957b1c8b41d8f17421652f676b6684f7.url(options),
+            method: 'post',
+        })
+    
+    store957b1c8b41d8f17421652f676b6684f7.form = store957b1c8b41d8f17421652f676b6684f7Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/dekan/admin/templates'
+ */
+const store8d93e22505e0269c341ad40364c118ce = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store8d93e22505e0269c341ad40364c118ce.url(options),
+    method: 'post',
+})
+
+store8d93e22505e0269c341ad40364c118ce.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/templates',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/dekan/admin/templates'
+ */
+store8d93e22505e0269c341ad40364c118ce.url = (options?: RouteQueryOptions) => {
+    return store8d93e22505e0269c341ad40364c118ce.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/dekan/admin/templates'
+ */
+store8d93e22505e0269c341ad40364c118ce.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: store8d93e22505e0269c341ad40364c118ce.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/dekan/admin/templates'
+ */
+    const store8d93e22505e0269c341ad40364c118ceForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store8d93e22505e0269c341ad40364c118ce.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::store
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:27
+ * @route '/dekan/admin/templates'
+ */
+        store8d93e22505e0269c341ad40364c118ceForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store8d93e22505e0269c341ad40364c118ce.url(options),
+            method: 'post',
+        })
+    
+    store8d93e22505e0269c341ad40364c118ce.form = store8d93e22505e0269c341ad40364c118ceForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\TemplateController::store, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `store['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const store = {
+    '/admin/templates': stored5705b7847a1ea5930840f23087f91b5,
+    '/kaprodi/admin/templates': store957b1c8b41d8f17421652f676b6684f7,
+    '/dekan/admin/templates': store8d93e22505e0269c341ad40364c118ce,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:35
-* @route '/admin/templates/{jenisSurat}/preview'
-*/
-export const preview = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: preview.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/admin/templates/{jenisSurat}/preview'
+ */
+const preview1458ea1a8e799b0a95dcddcf76bd62fd = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: preview1458ea1a8e799b0a95dcddcf76bd62fd.url(args, options),
     method: 'get',
 })
 
-preview.definition = {
+preview1458ea1a8e799b0a95dcddcf76bd62fd.definition = {
     methods: ["get","head"],
     url: '/admin/templates/{jenisSurat}/preview',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:35
-* @route '/admin/templates/{jenisSurat}/preview'
-*/
-preview.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/admin/templates/{jenisSurat}/preview'
+ */
+preview1458ea1a8e799b0a95dcddcf76bd62fd.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { jenisSurat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { jenisSurat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            jenisSurat: args[0],
-        }
+                    jenisSurat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        jenisSurat: typeof args.jenisSurat === 'object'
-        ? args.jenisSurat.id
-        : args.jenisSurat,
-    }
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
 
-    return preview.definition.url
+    return preview1458ea1a8e799b0a95dcddcf76bd62fd.definition.url
             .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:35
-* @route '/admin/templates/{jenisSurat}/preview'
-*/
-preview.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
-    url: preview.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/admin/templates/{jenisSurat}/preview'
+ */
+preview1458ea1a8e799b0a95dcddcf76bd62fd.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: preview1458ea1a8e799b0a95dcddcf76bd62fd.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:35
-* @route '/admin/templates/{jenisSurat}/preview'
-*/
-preview.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
-    url: preview.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/admin/templates/{jenisSurat}/preview'
+ */
+preview1458ea1a8e799b0a95dcddcf76bd62fd.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: preview1458ea1a8e799b0a95dcddcf76bd62fd.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/admin/templates/{jenisSurat}/preview'
+ */
+    const preview1458ea1a8e799b0a95dcddcf76bd62fdForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: preview1458ea1a8e799b0a95dcddcf76bd62fd.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/admin/templates/{jenisSurat}/preview'
+ */
+        preview1458ea1a8e799b0a95dcddcf76bd62fdForm.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: preview1458ea1a8e799b0a95dcddcf76bd62fd.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/admin/templates/{jenisSurat}/preview'
+ */
+        preview1458ea1a8e799b0a95dcddcf76bd62fdForm.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: preview1458ea1a8e799b0a95dcddcf76bd62fd.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    preview1458ea1a8e799b0a95dcddcf76bd62fd.form = preview1458ea1a8e799b0a95dcddcf76bd62fdForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/kaprodi/admin/templates/{jenisSurat}/preview'
+ */
+const preview4fa55105ba4d0389070cc8883e48cbd7 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: preview4fa55105ba4d0389070cc8883e48cbd7.url(args, options),
+    method: 'get',
+})
+
+preview4fa55105ba4d0389070cc8883e48cbd7.definition = {
+    methods: ["get","head"],
+    url: '/kaprodi/admin/templates/{jenisSurat}/preview',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/kaprodi/admin/templates/{jenisSurat}/preview'
+ */
+preview4fa55105ba4d0389070cc8883e48cbd7.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return preview4fa55105ba4d0389070cc8883e48cbd7.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/kaprodi/admin/templates/{jenisSurat}/preview'
+ */
+preview4fa55105ba4d0389070cc8883e48cbd7.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: preview4fa55105ba4d0389070cc8883e48cbd7.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/kaprodi/admin/templates/{jenisSurat}/preview'
+ */
+preview4fa55105ba4d0389070cc8883e48cbd7.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: preview4fa55105ba4d0389070cc8883e48cbd7.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/kaprodi/admin/templates/{jenisSurat}/preview'
+ */
+    const preview4fa55105ba4d0389070cc8883e48cbd7Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: preview4fa55105ba4d0389070cc8883e48cbd7.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/kaprodi/admin/templates/{jenisSurat}/preview'
+ */
+        preview4fa55105ba4d0389070cc8883e48cbd7Form.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: preview4fa55105ba4d0389070cc8883e48cbd7.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/kaprodi/admin/templates/{jenisSurat}/preview'
+ */
+        preview4fa55105ba4d0389070cc8883e48cbd7Form.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: preview4fa55105ba4d0389070cc8883e48cbd7.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    preview4fa55105ba4d0389070cc8883e48cbd7.form = preview4fa55105ba4d0389070cc8883e48cbd7Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/dekan/admin/templates/{jenisSurat}/preview'
+ */
+const preview6966d51cd43ca6a22a8ec9319baf124f = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: preview6966d51cd43ca6a22a8ec9319baf124f.url(args, options),
+    method: 'get',
+})
+
+preview6966d51cd43ca6a22a8ec9319baf124f.definition = {
+    methods: ["get","head"],
+    url: '/dekan/admin/templates/{jenisSurat}/preview',
+} satisfies RouteDefinition<["get","head"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/dekan/admin/templates/{jenisSurat}/preview'
+ */
+preview6966d51cd43ca6a22a8ec9319baf124f.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return preview6966d51cd43ca6a22a8ec9319baf124f.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/dekan/admin/templates/{jenisSurat}/preview'
+ */
+preview6966d51cd43ca6a22a8ec9319baf124f.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: preview6966d51cd43ca6a22a8ec9319baf124f.url(args, options),
+    method: 'get',
+})
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/dekan/admin/templates/{jenisSurat}/preview'
+ */
+preview6966d51cd43ca6a22a8ec9319baf124f.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: preview6966d51cd43ca6a22a8ec9319baf124f.url(args, options),
+    method: 'head',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/dekan/admin/templates/{jenisSurat}/preview'
+ */
+    const preview6966d51cd43ca6a22a8ec9319baf124fForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: preview6966d51cd43ca6a22a8ec9319baf124f.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/dekan/admin/templates/{jenisSurat}/preview'
+ */
+        preview6966d51cd43ca6a22a8ec9319baf124fForm.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: preview6966d51cd43ca6a22a8ec9319baf124f.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::preview
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:41
+ * @route '/dekan/admin/templates/{jenisSurat}/preview'
+ */
+        preview6966d51cd43ca6a22a8ec9319baf124fForm.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: preview6966d51cd43ca6a22a8ec9319baf124f.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    preview6966d51cd43ca6a22a8ec9319baf124f.form = preview6966d51cd43ca6a22a8ec9319baf124fForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\TemplateController::preview, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `preview['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const preview = {
+    '/admin/templates/{jenisSurat}/preview': preview1458ea1a8e799b0a95dcddcf76bd62fd,
+    '/kaprodi/admin/templates/{jenisSurat}/preview': preview4fa55105ba4d0389070cc8883e48cbd7,
+    '/dekan/admin/templates/{jenisSurat}/preview': preview6966d51cd43ca6a22a8ec9319baf124f,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:50
-* @route '/admin/templates/{jenisSurat}/duplicate'
-*/
-export const duplicate = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: duplicate.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/admin/templates/{jenisSurat}/duplicate'
+ */
+const duplicated7008cb62fc8bbec332e944dfd8460bd = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: duplicated7008cb62fc8bbec332e944dfd8460bd.url(args, options),
     method: 'post',
 })
 
-duplicate.definition = {
+duplicated7008cb62fc8bbec332e944dfd8460bd.definition = {
     methods: ["post"],
     url: '/admin/templates/{jenisSurat}/duplicate',
 } satisfies RouteDefinition<["post"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:50
-* @route '/admin/templates/{jenisSurat}/duplicate'
-*/
-duplicate.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/admin/templates/{jenisSurat}/duplicate'
+ */
+duplicated7008cb62fc8bbec332e944dfd8460bd.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { jenisSurat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { jenisSurat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            jenisSurat: args[0],
-        }
+                    jenisSurat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        jenisSurat: typeof args.jenisSurat === 'object'
-        ? args.jenisSurat.id
-        : args.jenisSurat,
-    }
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
 
-    return duplicate.definition.url
+    return duplicated7008cb62fc8bbec332e944dfd8460bd.definition.url
             .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:50
-* @route '/admin/templates/{jenisSurat}/duplicate'
-*/
-duplicate.post = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
-    url: duplicate.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/admin/templates/{jenisSurat}/duplicate'
+ */
+duplicated7008cb62fc8bbec332e944dfd8460bd.post = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: duplicated7008cb62fc8bbec332e944dfd8460bd.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/admin/templates/{jenisSurat}/duplicate'
+ */
+    const duplicated7008cb62fc8bbec332e944dfd8460bdForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: duplicated7008cb62fc8bbec332e944dfd8460bd.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/admin/templates/{jenisSurat}/duplicate'
+ */
+        duplicated7008cb62fc8bbec332e944dfd8460bdForm.post = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: duplicated7008cb62fc8bbec332e944dfd8460bd.url(args, options),
+            method: 'post',
+        })
+    
+    duplicated7008cb62fc8bbec332e944dfd8460bd.form = duplicated7008cb62fc8bbec332e944dfd8460bdForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/kaprodi/admin/templates/{jenisSurat}/duplicate'
+ */
+const duplicate1ccd8a00f5f6974c2de1e36645851e0c = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: duplicate1ccd8a00f5f6974c2de1e36645851e0c.url(args, options),
+    method: 'post',
+})
+
+duplicate1ccd8a00f5f6974c2de1e36645851e0c.definition = {
+    methods: ["post"],
+    url: '/kaprodi/admin/templates/{jenisSurat}/duplicate',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/kaprodi/admin/templates/{jenisSurat}/duplicate'
+ */
+duplicate1ccd8a00f5f6974c2de1e36645851e0c.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return duplicate1ccd8a00f5f6974c2de1e36645851e0c.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/kaprodi/admin/templates/{jenisSurat}/duplicate'
+ */
+duplicate1ccd8a00f5f6974c2de1e36645851e0c.post = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: duplicate1ccd8a00f5f6974c2de1e36645851e0c.url(args, options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/kaprodi/admin/templates/{jenisSurat}/duplicate'
+ */
+    const duplicate1ccd8a00f5f6974c2de1e36645851e0cForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: duplicate1ccd8a00f5f6974c2de1e36645851e0c.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/kaprodi/admin/templates/{jenisSurat}/duplicate'
+ */
+        duplicate1ccd8a00f5f6974c2de1e36645851e0cForm.post = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: duplicate1ccd8a00f5f6974c2de1e36645851e0c.url(args, options),
+            method: 'post',
+        })
+    
+    duplicate1ccd8a00f5f6974c2de1e36645851e0c.form = duplicate1ccd8a00f5f6974c2de1e36645851e0cForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/dekan/admin/templates/{jenisSurat}/duplicate'
+ */
+const duplicate578f79cf42c6bf57bff1b5009a62783c = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: duplicate578f79cf42c6bf57bff1b5009a62783c.url(args, options),
+    method: 'post',
+})
+
+duplicate578f79cf42c6bf57bff1b5009a62783c.definition = {
+    methods: ["post"],
+    url: '/dekan/admin/templates/{jenisSurat}/duplicate',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/dekan/admin/templates/{jenisSurat}/duplicate'
+ */
+duplicate578f79cf42c6bf57bff1b5009a62783c.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return duplicate578f79cf42c6bf57bff1b5009a62783c.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/dekan/admin/templates/{jenisSurat}/duplicate'
+ */
+duplicate578f79cf42c6bf57bff1b5009a62783c.post = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: duplicate578f79cf42c6bf57bff1b5009a62783c.url(args, options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/dekan/admin/templates/{jenisSurat}/duplicate'
+ */
+    const duplicate578f79cf42c6bf57bff1b5009a62783cForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: duplicate578f79cf42c6bf57bff1b5009a62783c.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:62
+ * @route '/dekan/admin/templates/{jenisSurat}/duplicate'
+ */
+        duplicate578f79cf42c6bf57bff1b5009a62783cForm.post = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: duplicate578f79cf42c6bf57bff1b5009a62783c.url(args, options),
+            method: 'post',
+        })
+    
+    duplicate578f79cf42c6bf57bff1b5009a62783c.form = duplicate578f79cf42c6bf57bff1b5009a62783cForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\TemplateController::duplicate, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `duplicate['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const duplicate = {
+    '/admin/templates/{jenisSurat}/duplicate': duplicated7008cb62fc8bbec332e944dfd8460bd,
+    '/kaprodi/admin/templates/{jenisSurat}/duplicate': duplicate1ccd8a00f5f6974c2de1e36645851e0c,
+    '/dekan/admin/templates/{jenisSurat}/duplicate': duplicate578f79cf42c6bf57bff1b5009a62783c,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:45
-* @route '/admin/templates/{jenisSurat}/toggle-active'
-*/
-export const toggleActive = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
-    url: toggleActive.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/admin/templates/{jenisSurat}/toggle-active'
+ */
+const toggleActive24eb9428d4dc6193900a741f68e73a1a = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: toggleActive24eb9428d4dc6193900a741f68e73a1a.url(args, options),
     method: 'patch',
 })
 
-toggleActive.definition = {
+toggleActive24eb9428d4dc6193900a741f68e73a1a.definition = {
     methods: ["patch"],
     url: '/admin/templates/{jenisSurat}/toggle-active',
 } satisfies RouteDefinition<["patch"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:45
-* @route '/admin/templates/{jenisSurat}/toggle-active'
-*/
-toggleActive.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/admin/templates/{jenisSurat}/toggle-active'
+ */
+toggleActive24eb9428d4dc6193900a741f68e73a1a.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { jenisSurat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { jenisSurat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            jenisSurat: args[0],
-        }
+                    jenisSurat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        jenisSurat: typeof args.jenisSurat === 'object'
-        ? args.jenisSurat.id
-        : args.jenisSurat,
-    }
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
 
-    return toggleActive.definition.url
+    return toggleActive24eb9428d4dc6193900a741f68e73a1a.definition.url
             .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:45
-* @route '/admin/templates/{jenisSurat}/toggle-active'
-*/
-toggleActive.patch = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
-    url: toggleActive.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/admin/templates/{jenisSurat}/toggle-active'
+ */
+toggleActive24eb9428d4dc6193900a741f68e73a1a.patch = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: toggleActive24eb9428d4dc6193900a741f68e73a1a.url(args, options),
     method: 'patch',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/admin/templates/{jenisSurat}/toggle-active'
+ */
+    const toggleActive24eb9428d4dc6193900a741f68e73a1aForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: toggleActive24eb9428d4dc6193900a741f68e73a1a.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PATCH',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/admin/templates/{jenisSurat}/toggle-active'
+ */
+        toggleActive24eb9428d4dc6193900a741f68e73a1aForm.patch = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: toggleActive24eb9428d4dc6193900a741f68e73a1a.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    toggleActive24eb9428d4dc6193900a741f68e73a1a.form = toggleActive24eb9428d4dc6193900a741f68e73a1aForm
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/kaprodi/admin/templates/{jenisSurat}/toggle-active'
+ */
+const toggleActiveefada02b3e0ad96868cf0f64f4e173a0 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: toggleActiveefada02b3e0ad96868cf0f64f4e173a0.url(args, options),
+    method: 'patch',
+})
+
+toggleActiveefada02b3e0ad96868cf0f64f4e173a0.definition = {
+    methods: ["patch"],
+    url: '/kaprodi/admin/templates/{jenisSurat}/toggle-active',
+} satisfies RouteDefinition<["patch"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/kaprodi/admin/templates/{jenisSurat}/toggle-active'
+ */
+toggleActiveefada02b3e0ad96868cf0f64f4e173a0.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return toggleActiveefada02b3e0ad96868cf0f64f4e173a0.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/kaprodi/admin/templates/{jenisSurat}/toggle-active'
+ */
+toggleActiveefada02b3e0ad96868cf0f64f4e173a0.patch = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: toggleActiveefada02b3e0ad96868cf0f64f4e173a0.url(args, options),
+    method: 'patch',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/kaprodi/admin/templates/{jenisSurat}/toggle-active'
+ */
+    const toggleActiveefada02b3e0ad96868cf0f64f4e173a0Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: toggleActiveefada02b3e0ad96868cf0f64f4e173a0.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PATCH',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/kaprodi/admin/templates/{jenisSurat}/toggle-active'
+ */
+        toggleActiveefada02b3e0ad96868cf0f64f4e173a0Form.patch = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: toggleActiveefada02b3e0ad96868cf0f64f4e173a0.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    toggleActiveefada02b3e0ad96868cf0f64f4e173a0.form = toggleActiveefada02b3e0ad96868cf0f64f4e173a0Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/dekan/admin/templates/{jenisSurat}/toggle-active'
+ */
+const toggleActive05c38a44eb5f8a0851cf2c52a0b975ee = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: toggleActive05c38a44eb5f8a0851cf2c52a0b975ee.url(args, options),
+    method: 'patch',
+})
+
+toggleActive05c38a44eb5f8a0851cf2c52a0b975ee.definition = {
+    methods: ["patch"],
+    url: '/dekan/admin/templates/{jenisSurat}/toggle-active',
+} satisfies RouteDefinition<["patch"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/dekan/admin/templates/{jenisSurat}/toggle-active'
+ */
+toggleActive05c38a44eb5f8a0851cf2c52a0b975ee.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return toggleActive05c38a44eb5f8a0851cf2c52a0b975ee.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/dekan/admin/templates/{jenisSurat}/toggle-active'
+ */
+toggleActive05c38a44eb5f8a0851cf2c52a0b975ee.patch = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: toggleActive05c38a44eb5f8a0851cf2c52a0b975ee.url(args, options),
+    method: 'patch',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/dekan/admin/templates/{jenisSurat}/toggle-active'
+ */
+    const toggleActive05c38a44eb5f8a0851cf2c52a0b975eeForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: toggleActive05c38a44eb5f8a0851cf2c52a0b975ee.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PATCH',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:55
+ * @route '/dekan/admin/templates/{jenisSurat}/toggle-active'
+ */
+        toggleActive05c38a44eb5f8a0851cf2c52a0b975eeForm.patch = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: toggleActive05c38a44eb5f8a0851cf2c52a0b975ee.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    toggleActive05c38a44eb5f8a0851cf2c52a0b975ee.form = toggleActive05c38a44eb5f8a0851cf2c52a0b975eeForm
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\TemplateController::toggleActive, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `toggleActive['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const toggleActive = {
+    '/admin/templates/{jenisSurat}/toggle-active': toggleActive24eb9428d4dc6193900a741f68e73a1a,
+    '/kaprodi/admin/templates/{jenisSurat}/toggle-active': toggleActiveefada02b3e0ad96868cf0f64f4e173a0,
+    '/dekan/admin/templates/{jenisSurat}/toggle-active': toggleActive05c38a44eb5f8a0851cf2c52a0b975ee,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:30
-* @route '/admin/templates/{jenisSurat}'
-*/
-export const update = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
-    url: update.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/admin/templates/{jenisSurat}'
+ */
+const update01f505c1b215cb09c80c65f20012e257 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update01f505c1b215cb09c80c65f20012e257.url(args, options),
     method: 'put',
 })
 
-update.definition = {
+update01f505c1b215cb09c80c65f20012e257.definition = {
     methods: ["put"],
     url: '/admin/templates/{jenisSurat}',
 } satisfies RouteDefinition<["put"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:30
-* @route '/admin/templates/{jenisSurat}'
-*/
-update.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/admin/templates/{jenisSurat}'
+ */
+update01f505c1b215cb09c80c65f20012e257.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { jenisSurat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { jenisSurat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            jenisSurat: args[0],
-        }
+                    jenisSurat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        jenisSurat: typeof args.jenisSurat === 'object'
-        ? args.jenisSurat.id
-        : args.jenisSurat,
-    }
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
 
-    return update.definition.url
+    return update01f505c1b215cb09c80c65f20012e257.definition.url
             .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:30
-* @route '/admin/templates/{jenisSurat}'
-*/
-update.put = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
-    url: update.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/admin/templates/{jenisSurat}'
+ */
+update01f505c1b215cb09c80c65f20012e257.put = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: update01f505c1b215cb09c80c65f20012e257.url(args, options),
     method: 'put',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/admin/templates/{jenisSurat}'
+ */
+    const update01f505c1b215cb09c80c65f20012e257Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update01f505c1b215cb09c80c65f20012e257.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/admin/templates/{jenisSurat}'
+ */
+        update01f505c1b215cb09c80c65f20012e257Form.put = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update01f505c1b215cb09c80c65f20012e257.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update01f505c1b215cb09c80c65f20012e257.form = update01f505c1b215cb09c80c65f20012e257Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+const updateec4553acf41ea339119e762c715217a1 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: updateec4553acf41ea339119e762c715217a1.url(args, options),
+    method: 'put',
+})
+
+updateec4553acf41ea339119e762c715217a1.definition = {
+    methods: ["put"],
+    url: '/kaprodi/admin/templates/{jenisSurat}',
+} satisfies RouteDefinition<["put"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+updateec4553acf41ea339119e762c715217a1.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return updateec4553acf41ea339119e762c715217a1.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+updateec4553acf41ea339119e762c715217a1.put = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: updateec4553acf41ea339119e762c715217a1.url(args, options),
+    method: 'put',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+    const updateec4553acf41ea339119e762c715217a1Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: updateec4553acf41ea339119e762c715217a1.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+        updateec4553acf41ea339119e762c715217a1Form.put = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: updateec4553acf41ea339119e762c715217a1.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    updateec4553acf41ea339119e762c715217a1.form = updateec4553acf41ea339119e762c715217a1Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+const updatee90c4242e6221d90cc466e8c8b71bc81 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: updatee90c4242e6221d90cc466e8c8b71bc81.url(args, options),
+    method: 'put',
+})
+
+updatee90c4242e6221d90cc466e8c8b71bc81.definition = {
+    methods: ["put"],
+    url: '/dekan/admin/templates/{jenisSurat}',
+} satisfies RouteDefinition<["put"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+updatee90c4242e6221d90cc466e8c8b71bc81.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return updatee90c4242e6221d90cc466e8c8b71bc81.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+updatee90c4242e6221d90cc466e8c8b71bc81.put = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: updatee90c4242e6221d90cc466e8c8b71bc81.url(args, options),
+    method: 'put',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+    const updatee90c4242e6221d90cc466e8c8b71bc81Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: updatee90c4242e6221d90cc466e8c8b71bc81.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::update
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:34
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+        updatee90c4242e6221d90cc466e8c8b71bc81Form.put = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: updatee90c4242e6221d90cc466e8c8b71bc81.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    updatee90c4242e6221d90cc466e8c8b71bc81.form = updatee90c4242e6221d90cc466e8c8b71bc81Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\TemplateController::update, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `update['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const update = {
+    '/admin/templates/{jenisSurat}': update01f505c1b215cb09c80c65f20012e257,
+    '/kaprodi/admin/templates/{jenisSurat}': updateec4553acf41ea339119e762c715217a1,
+    '/dekan/admin/templates/{jenisSurat}': updatee90c4242e6221d90cc466e8c8b71bc81,
+}
+
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:40
-* @route '/admin/templates/{jenisSurat}'
-*/
-export const destroy = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
-    url: destroy.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/admin/templates/{jenisSurat}'
+ */
+const destroy01f505c1b215cb09c80c65f20012e257 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy01f505c1b215cb09c80c65f20012e257.url(args, options),
     method: 'delete',
 })
 
-destroy.definition = {
+destroy01f505c1b215cb09c80c65f20012e257.definition = {
     methods: ["delete"],
     url: '/admin/templates/{jenisSurat}',
 } satisfies RouteDefinition<["delete"]>
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:40
-* @route '/admin/templates/{jenisSurat}'
-*/
-destroy.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/admin/templates/{jenisSurat}'
+ */
+destroy01f505c1b215cb09c80c65f20012e257.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { jenisSurat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { jenisSurat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            jenisSurat: args[0],
-        }
+                    jenisSurat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        jenisSurat: typeof args.jenisSurat === 'object'
-        ? args.jenisSurat.id
-        : args.jenisSurat,
-    }
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
 
-    return destroy.definition.url
+    return destroy01f505c1b215cb09c80c65f20012e257.definition.url
             .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
             .replace(/\/+$/, '') + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
-* @see app/Modules/Fast/Controllers/Admin/TemplateController.php:40
-* @route '/admin/templates/{jenisSurat}'
-*/
-destroy.delete = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
-    url: destroy.url(args, options),
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/admin/templates/{jenisSurat}'
+ */
+destroy01f505c1b215cb09c80c65f20012e257.delete = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroy01f505c1b215cb09c80c65f20012e257.url(args, options),
     method: 'delete',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/admin/templates/{jenisSurat}'
+ */
+    const destroy01f505c1b215cb09c80c65f20012e257Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroy01f505c1b215cb09c80c65f20012e257.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/admin/templates/{jenisSurat}'
+ */
+        destroy01f505c1b215cb09c80c65f20012e257Form.delete = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroy01f505c1b215cb09c80c65f20012e257.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroy01f505c1b215cb09c80c65f20012e257.form = destroy01f505c1b215cb09c80c65f20012e257Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+const destroyec4553acf41ea339119e762c715217a1 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroyec4553acf41ea339119e762c715217a1.url(args, options),
+    method: 'delete',
+})
+
+destroyec4553acf41ea339119e762c715217a1.definition = {
+    methods: ["delete"],
+    url: '/kaprodi/admin/templates/{jenisSurat}',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+destroyec4553acf41ea339119e762c715217a1.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return destroyec4553acf41ea339119e762c715217a1.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+destroyec4553acf41ea339119e762c715217a1.delete = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroyec4553acf41ea339119e762c715217a1.url(args, options),
+    method: 'delete',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+    const destroyec4553acf41ea339119e762c715217a1Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroyec4553acf41ea339119e762c715217a1.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/kaprodi/admin/templates/{jenisSurat}'
+ */
+        destroyec4553acf41ea339119e762c715217a1Form.delete = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroyec4553acf41ea339119e762c715217a1.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroyec4553acf41ea339119e762c715217a1.form = destroyec4553acf41ea339119e762c715217a1Form
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+const destroye90c4242e6221d90cc466e8c8b71bc81 = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroye90c4242e6221d90cc466e8c8b71bc81.url(args, options),
+    method: 'delete',
+})
+
+destroye90c4242e6221d90cc466e8c8b71bc81.definition = {
+    methods: ["delete"],
+    url: '/dekan/admin/templates/{jenisSurat}',
+} satisfies RouteDefinition<["delete"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+destroye90c4242e6221d90cc466e8c8b71bc81.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
+    if (typeof args === 'string' || typeof args === 'number') {
+        args = { jenisSurat: args }
+    }
+
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
+    if (Array.isArray(args)) {
+        args = {
+                    jenisSurat: args[0],
+                }
+    }
+
+    args = applyUrlDefaults(args)
+
+    const parsedArgs = {
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
+
+    return destroye90c4242e6221d90cc466e8c8b71bc81.definition.url
+            .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
+            .replace(/\/+$/, '') + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+destroye90c4242e6221d90cc466e8c8b71bc81.delete = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: destroye90c4242e6221d90cc466e8c8b71bc81.url(args, options),
+    method: 'delete',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+    const destroye90c4242e6221d90cc466e8c8b71bc81Form = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroye90c4242e6221d90cc466e8c8b71bc81.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Admin\TemplateController::destroy
+ * @see app/Modules/Fast/Controllers/Admin/TemplateController.php:48
+ * @route '/dekan/admin/templates/{jenisSurat}'
+ */
+        destroye90c4242e6221d90cc466e8c8b71bc81Form.delete = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroye90c4242e6221d90cc466e8c8b71bc81.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroye90c4242e6221d90cc466e8c8b71bc81.form = destroye90c4242e6221d90cc466e8c8b71bc81Form
+
+/**
+* Multiple routes resolve to \App\Modules\Fast\Controllers\Admin\TemplateController::destroy, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `destroy['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
+export const destroy = {
+    '/admin/templates/{jenisSurat}': destroy01f505c1b215cb09c80c65f20012e257,
+    '/kaprodi/admin/templates/{jenisSurat}': destroyec4553acf41ea339119e762c715217a1,
+    '/dekan/admin/templates/{jenisSurat}': destroye90c4242e6221d90cc466e8c8b71bc81,
+}
 
 const TemplateController = { index, store, preview, duplicate, toggleActive, update, destroy }
 

--- a/resources/js/actions/App/Modules/Fast/Controllers/Admin/index.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Admin/index.ts
@@ -7,17 +7,16 @@ import TemplateController from './TemplateController'
 import CategoryController from './CategoryController'
 import QrManageController from './QrManageController'
 import GlobalSettingsController from './GlobalSettingsController'
-
 const Admin = {
     DashboardController: Object.assign(DashboardController, DashboardController),
-    LetterController: Object.assign(LetterController, LetterController),
-    ArchiveController: Object.assign(ArchiveController, ArchiveController),
-    LetterIndexController: Object.assign(LetterIndexController, LetterIndexController),
-    HistoryController: Object.assign(HistoryController, HistoryController),
-    TemplateController: Object.assign(TemplateController, TemplateController),
-    CategoryController: Object.assign(CategoryController, CategoryController),
-    QrManageController: Object.assign(QrManageController, QrManageController),
-    GlobalSettingsController: Object.assign(GlobalSettingsController, GlobalSettingsController),
+LetterController: Object.assign(LetterController, LetterController),
+ArchiveController: Object.assign(ArchiveController, ArchiveController),
+LetterIndexController: Object.assign(LetterIndexController, LetterIndexController),
+HistoryController: Object.assign(HistoryController, HistoryController),
+TemplateController: Object.assign(TemplateController, TemplateController),
+CategoryController: Object.assign(CategoryController, CategoryController),
+QrManageController: Object.assign(QrManageController, QrManageController),
+GlobalSettingsController: Object.assign(GlobalSettingsController, GlobalSettingsController),
 }
 
 export default Admin

--- a/resources/js/actions/App/Modules/Fast/Controllers/Dekan/ApprovalController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Dekan/ApprovalController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:21
-* @route '/dekan/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:24
+ * @route '/dekan/dashboard'
+ */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ index.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:21
-* @route '/dekan/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:24
+ * @route '/dekan/dashboard'
+ */
 index.url = (options?: RouteQueryOptions) => {
     return index.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:21
-* @route '/dekan/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:24
+ * @route '/dekan/dashboard'
+ */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:21
-* @route '/dekan/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:24
+ * @route '/dekan/dashboard'
+ */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::index
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:24
+ * @route '/dekan/dashboard'
+ */
+    const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::index
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:24
+ * @route '/dekan/dashboard'
+ */
+        indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::index
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:24
+ * @route '/dekan/dashboard'
+ */
+        indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index.form = indexForm
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:26
-* @route '/dekan/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
+ * @route '/dekan/antrian'
+ */
 export const queue = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: queue.url(options),
     method: 'get',
@@ -60,38 +94,72 @@ queue.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:26
-* @route '/dekan/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
+ * @route '/dekan/antrian'
+ */
 queue.url = (options?: RouteQueryOptions) => {
     return queue.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:26
-* @route '/dekan/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
+ * @route '/dekan/antrian'
+ */
 queue.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: queue.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:26
-* @route '/dekan/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
+ * @route '/dekan/antrian'
+ */
 queue.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: queue.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::queue
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
+ * @route '/dekan/antrian'
+ */
+    const queueForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: queue.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::queue
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
+ * @route '/dekan/antrian'
+ */
+        queueForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: queue.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::queue
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
+ * @route '/dekan/antrian'
+ */
+        queueForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: queue.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    queue.form = queueForm
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
-* @route '/dekan/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:38
+ * @route '/dekan/arsip'
+ */
 export const archive = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: archive.url(options),
     method: 'get',
@@ -104,38 +172,72 @@ archive.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
-* @route '/dekan/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:38
+ * @route '/dekan/arsip'
+ */
 archive.url = (options?: RouteQueryOptions) => {
     return archive.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
-* @route '/dekan/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:38
+ * @route '/dekan/arsip'
+ */
 archive.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: archive.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:31
-* @route '/dekan/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:38
+ * @route '/dekan/arsip'
+ */
 archive.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: archive.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::archive
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:38
+ * @route '/dekan/arsip'
+ */
+    const archiveForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: archive.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::archive
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:38
+ * @route '/dekan/arsip'
+ */
+        archiveForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: archive.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::archive
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:38
+ * @route '/dekan/arsip'
+ */
+        archiveForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: archive.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    archive.form = archiveForm
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:41
-* @route '/dekan/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:52
+ * @route '/dekan/surat/{id}/detail'
+ */
 export const detail = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: detail.url(args, options),
     method: 'get',
@@ -148,25 +250,26 @@ detail.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:41
-* @route '/dekan/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:52
+ * @route '/dekan/surat/{id}/detail'
+ */
 detail.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return detail.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -175,29 +278,63 @@ detail.url = (args: { id: string | number } | [id: string | number ] | string | 
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:41
-* @route '/dekan/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:52
+ * @route '/dekan/surat/{id}/detail'
+ */
 detail.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: detail.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:41
-* @route '/dekan/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:52
+ * @route '/dekan/surat/{id}/detail'
+ */
 detail.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: detail.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::detail
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:52
+ * @route '/dekan/surat/{id}/detail'
+ */
+    const detailForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: detail.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::detail
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:52
+ * @route '/dekan/surat/{id}/detail'
+ */
+        detailForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: detail.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::detail
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:52
+ * @route '/dekan/surat/{id}/detail'
+ */
+        detailForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: detail.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    detail.form = detailForm
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:46
-* @route '/dekan/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:60
+ * @route '/dekan/surat/{id}'
+ */
 export const show = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
@@ -210,25 +347,26 @@ show.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:46
-* @route '/dekan/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:60
+ * @route '/dekan/surat/{id}'
+ */
 show.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return show.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -237,29 +375,63 @@ show.url = (args: { id: string | number } | [id: string | number ] | string | nu
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:46
-* @route '/dekan/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:60
+ * @route '/dekan/surat/{id}'
+ */
 show.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:46
-* @route '/dekan/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:60
+ * @route '/dekan/surat/{id}'
+ */
 show.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::show
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:60
+ * @route '/dekan/surat/{id}'
+ */
+    const showForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::show
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:60
+ * @route '/dekan/surat/{id}'
+ */
+        showForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::show
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:60
+ * @route '/dekan/surat/{id}'
+ */
+        showForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:51
-* @route '/dekan/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:68
+ * @route '/dekan/lampiran/{id}/preview'
+ */
 export const previewAttachment = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment.url(args, options),
     method: 'get',
@@ -272,25 +444,26 @@ previewAttachment.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:51
-* @route '/dekan/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:68
+ * @route '/dekan/lampiran/{id}/preview'
+ */
 previewAttachment.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewAttachment.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -299,29 +472,63 @@ previewAttachment.url = (args: { id: string | number } | [id: string | number ] 
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:51
-* @route '/dekan/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:68
+ * @route '/dekan/lampiran/{id}/preview'
+ */
 previewAttachment.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:51
-* @route '/dekan/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:68
+ * @route '/dekan/lampiran/{id}/preview'
+ */
 previewAttachment.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewAttachment.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:68
+ * @route '/dekan/lampiran/{id}/preview'
+ */
+    const previewAttachmentForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewAttachment.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:68
+ * @route '/dekan/lampiran/{id}/preview'
+ */
+        previewAttachmentForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:68
+ * @route '/dekan/lampiran/{id}/preview'
+ */
+        previewAttachmentForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewAttachment.form = previewAttachmentForm
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::approve
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:56
-* @route '/dekan/surat/{id}/approve'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:82
+ * @route '/dekan/surat/{id}/approve'
+ */
 export const approve = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: approve.url(args, options),
     method: 'post',
@@ -334,25 +541,26 @@ approve.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::approve
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:56
-* @route '/dekan/surat/{id}/approve'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:82
+ * @route '/dekan/surat/{id}/approve'
+ */
 approve.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return approve.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -361,19 +569,95 @@ approve.url = (args: { id: string | number } | [id: string | number ] | string |
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::approve
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:56
-* @route '/dekan/surat/{id}/approve'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:82
+ * @route '/dekan/surat/{id}/approve'
+ */
 approve.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: approve.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::approve
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:82
+ * @route '/dekan/surat/{id}/approve'
+ */
+    const approveForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: approve.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::approve
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:82
+ * @route '/dekan/surat/{id}/approve'
+ */
+        approveForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: approve.url(args, options),
+            method: 'post',
+        })
+    
+    approve.form = approveForm
+/**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:90
+ * @route '/dekan/surat/bulk-approve'
+ */
+export const bulkApprove = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove.url(options),
+    method: 'post',
+})
+
+bulkApprove.definition = {
+    methods: ["post"],
+    url: '/dekan/surat/bulk-approve',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:90
+ * @route '/dekan/surat/bulk-approve'
+ */
+bulkApprove.url = (options?: RouteQueryOptions) => {
+    return bulkApprove.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:90
+ * @route '/dekan/surat/bulk-approve'
+ */
+bulkApprove.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:90
+ * @route '/dekan/surat/bulk-approve'
+ */
+    const bulkApproveForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: bulkApprove.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:90
+ * @route '/dekan/surat/bulk-approve'
+ */
+        bulkApproveForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: bulkApprove.url(options),
+            method: 'post',
+        })
+    
+    bulkApprove.form = bulkApproveForm
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::reject
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:66
-* @route '/dekan/surat/{id}/reject'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:120
+ * @route '/dekan/surat/{id}/reject'
+ */
 export const reject = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: reject.url(args, options),
     method: 'post',
@@ -386,25 +670,26 @@ reject.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::reject
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:66
-* @route '/dekan/surat/{id}/reject'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:120
+ * @route '/dekan/surat/{id}/reject'
+ */
 reject.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return reject.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -413,19 +698,40 @@ reject.url = (args: { id: string | number } | [id: string | number ] | string | 
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::reject
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:66
-* @route '/dekan/surat/{id}/reject'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:120
+ * @route '/dekan/surat/{id}/reject'
+ */
 reject.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: reject.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::reject
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:120
+ * @route '/dekan/surat/{id}/reject'
+ */
+    const rejectForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: reject.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::reject
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:120
+ * @route '/dekan/surat/{id}/reject'
+ */
+        rejectForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: reject.url(args, options),
+            method: 'post',
+        })
+    
+    reject.form = rejectForm
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::finalReject
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:71
-* @route '/dekan/surat/{id}/final-reject'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:128
+ * @route '/dekan/surat/{id}/final-reject'
+ */
 export const finalReject = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: finalReject.url(args, options),
     method: 'post',
@@ -438,25 +744,26 @@ finalReject.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::finalReject
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:71
-* @route '/dekan/surat/{id}/final-reject'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:128
+ * @route '/dekan/surat/{id}/final-reject'
+ */
 finalReject.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return finalReject.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -465,19 +772,40 @@ finalReject.url = (args: { id: string | number } | [id: string | number ] | stri
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::finalReject
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:71
-* @route '/dekan/surat/{id}/final-reject'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:128
+ * @route '/dekan/surat/{id}/final-reject'
+ */
 finalReject.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: finalReject.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::finalReject
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:128
+ * @route '/dekan/surat/{id}/final-reject'
+ */
+    const finalRejectForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: finalReject.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::finalReject
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:128
+ * @route '/dekan/surat/{id}/final-reject'
+ */
+        finalRejectForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: finalReject.url(args, options),
+            method: 'post',
+        })
+    
+    finalReject.form = finalRejectForm
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::saveNote
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:61
-* @route '/dekan/surat/{id}/note'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:112
+ * @route '/dekan/surat/{id}/note'
+ */
 export const saveNote = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: saveNote.url(args, options),
     method: 'post',
@@ -490,25 +818,26 @@ saveNote.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::saveNote
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:61
-* @route '/dekan/surat/{id}/note'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:112
+ * @route '/dekan/surat/{id}/note'
+ */
 saveNote.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return saveNote.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -517,14 +846,35 @@ saveNote.url = (args: { id: string | number } | [id: string | number ] | string 
 
 /**
 * @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::saveNote
-* @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:61
-* @route '/dekan/surat/{id}/note'
-*/
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:112
+ * @route '/dekan/surat/{id}/note'
+ */
 saveNote.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: saveNote.url(args, options),
     method: 'post',
 })
 
-const ApprovalController = { index, queue, archive, detail, show, previewAttachment, approve, reject, finalReject, saveNote }
+    /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::saveNote
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:112
+ * @route '/dekan/surat/{id}/note'
+ */
+    const saveNoteForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: saveNote.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dekan\ApprovalController::saveNote
+ * @see app/Modules/Fast/Controllers/Dekan/ApprovalController.php:112
+ * @route '/dekan/surat/{id}/note'
+ */
+        saveNoteForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: saveNote.url(args, options),
+            method: 'post',
+        })
+    
+    saveNote.form = saveNoteForm
+const ApprovalController = { index, queue, archive, detail, show, previewAttachment, approve, bulkApprove, reject, finalReject, saveNote }
 
 export default ApprovalController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Dekan/index.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Dekan/index.ts
@@ -1,5 +1,4 @@
 import ApprovalController from './ApprovalController'
-
 const Dekan = {
     ApprovalController: Object.assign(ApprovalController, ApprovalController),
 }

--- a/resources/js/actions/App/Modules/Fast/Controllers/Dosen/DashboardController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Dosen/DashboardController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\DashboardController::index
-* @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
-* @route '/dosen/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
+ * @route '/dosen/dashboard'
+ */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
@@ -16,33 +16,67 @@ index.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\DashboardController::index
-* @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
-* @route '/dosen/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
+ * @route '/dosen/dashboard'
+ */
 index.url = (options?: RouteQueryOptions) => {
     return index.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\DashboardController::index
-* @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
-* @route '/dosen/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
+ * @route '/dosen/dashboard'
+ */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\DashboardController::index
-* @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
-* @route '/dosen/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
+ * @route '/dosen/dashboard'
+ */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dosen\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
+ * @route '/dosen/dashboard'
+ */
+    const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
+ * @route '/dosen/dashboard'
+ */
+        indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Dosen/DashboardController.php:19
+ * @route '/dosen/dashboard'
+ */
+        indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index.form = indexForm
 const DashboardController = { index }
 
 export default DashboardController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Dosen/HistoryController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Dosen/HistoryController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::index
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:16
-* @route '/dosen/history'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:17
+ * @route '/dosen/history'
+ */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ index.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::index
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:16
-* @route '/dosen/history'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:17
+ * @route '/dosen/history'
+ */
 index.url = (options?: RouteQueryOptions) => {
     return index.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::index
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:16
-* @route '/dosen/history'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:17
+ * @route '/dosen/history'
+ */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::index
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:16
-* @route '/dosen/history'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:17
+ * @route '/dosen/history'
+ */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dosen\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:17
+ * @route '/dosen/history'
+ */
+    const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:17
+ * @route '/dosen/history'
+ */
+        indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:17
+ * @route '/dosen/history'
+ */
+        indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index.form = indexForm
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::show
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:53
-* @route '/dosen/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:75
+ * @route '/dosen/history/{id}'
+ */
 export const show = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
@@ -60,25 +94,26 @@ show.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::show
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:53
-* @route '/dosen/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:75
+ * @route '/dosen/history/{id}'
+ */
 show.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return show.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -87,29 +122,63 @@ show.url = (args: { id: string | number } | [id: string | number ] | string | nu
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::show
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:53
-* @route '/dosen/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:75
+ * @route '/dosen/history/{id}'
+ */
 show.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::show
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:53
-* @route '/dosen/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:75
+ * @route '/dosen/history/{id}'
+ */
 show.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dosen\HistoryController::show
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:75
+ * @route '/dosen/history/{id}'
+ */
+    const showForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\HistoryController::show
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:75
+ * @route '/dosen/history/{id}'
+ */
+        showForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\HistoryController::show
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:75
+ * @route '/dosen/history/{id}'
+ */
+        showForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::cancel
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:178
-* @route '/dosen/surat/{id}/cancel'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:217
+ * @route '/dosen/surat/{id}/cancel'
+ */
 export const cancel = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: cancel.url(args, options),
     method: 'post',
@@ -122,25 +191,26 @@ cancel.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::cancel
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:178
-* @route '/dosen/surat/{id}/cancel'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:217
+ * @route '/dosen/surat/{id}/cancel'
+ */
 cancel.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return cancel.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -149,14 +219,35 @@ cancel.url = (args: { id: string | number } | [id: string | number ] | string | 
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\HistoryController::cancel
-* @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:178
-* @route '/dosen/surat/{id}/cancel'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:217
+ * @route '/dosen/surat/{id}/cancel'
+ */
 cancel.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: cancel.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dosen\HistoryController::cancel
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:217
+ * @route '/dosen/surat/{id}/cancel'
+ */
+    const cancelForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: cancel.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\HistoryController::cancel
+ * @see app/Modules/Fast/Controllers/Dosen/HistoryController.php:217
+ * @route '/dosen/surat/{id}/cancel'
+ */
+        cancelForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: cancel.url(args, options),
+            method: 'post',
+        })
+    
+    cancel.form = cancelForm
 const HistoryController = { index, show, cancel }
 
 export default HistoryController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Dosen/LetterTypeController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Dosen/LetterTypeController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\LetterTypeController::show
-* @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
-* @route '/dosen/jenis-surat/{jenisSurat}'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
+ * @route '/dosen/jenis-surat/{jenisSurat}'
+ */
 export const show = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
@@ -16,31 +16,31 @@ show.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\LetterTypeController::show
-* @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
-* @route '/dosen/jenis-surat/{jenisSurat}'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
+ * @route '/dosen/jenis-surat/{jenisSurat}'
+ */
 show.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { jenisSurat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { jenisSurat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            jenisSurat: args[0],
-        }
+                    jenisSurat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        jenisSurat: typeof args.jenisSurat === 'object'
-        ? args.jenisSurat.id
-        : args.jenisSurat,
-    }
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
 
     return show.definition.url
             .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
@@ -49,24 +49,58 @@ show.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number 
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\LetterTypeController::show
-* @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
-* @route '/dosen/jenis-surat/{jenisSurat}'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
+ * @route '/dosen/jenis-surat/{jenisSurat}'
+ */
 show.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\LetterTypeController::show
-* @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
-* @route '/dosen/jenis-surat/{jenisSurat}'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
+ * @route '/dosen/jenis-surat/{jenisSurat}'
+ */
 show.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dosen\LetterTypeController::show
+ * @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
+ * @route '/dosen/jenis-surat/{jenisSurat}'
+ */
+    const showForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\LetterTypeController::show
+ * @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
+ * @route '/dosen/jenis-surat/{jenisSurat}'
+ */
+        showForm.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\LetterTypeController::show
+ * @see app/Modules/Fast/Controllers/Dosen/LetterTypeController.php:13
+ * @route '/dosen/jenis-surat/{jenisSurat}'
+ */
+        showForm.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 const LetterTypeController = { show }
 
 export default LetterTypeController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Dosen/SubmissionController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Dosen/SubmissionController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
-* @route '/dosen/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
+ * @route '/dosen/ajukan'
+ */
 export const create = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ create.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
-* @route '/dosen/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
+ * @route '/dosen/ajukan'
+ */
 create.url = (options?: RouteQueryOptions) => {
     return create.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
-* @route '/dosen/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
+ * @route '/dosen/ajukan'
+ */
 create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
-* @route '/dosen/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
+ * @route '/dosen/ajukan'
+ */
 create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: create.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::create
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
+ * @route '/dosen/ajukan'
+ */
+    const createForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: create.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::create
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
+ * @route '/dosen/ajukan'
+ */
+        createForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::create
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:28
+ * @route '/dosen/ajukan'
+ */
+        createForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    create.form = createForm
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::store
-* @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:120
-* @route '/dosen/submissions'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:121
+ * @route '/dosen/submissions'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -60,23 +94,44 @@ store.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::store
-* @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:120
-* @route '/dosen/submissions'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:121
+ * @route '/dosen/submissions'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::store
-* @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:120
-* @route '/dosen/submissions'
-*/
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:121
+ * @route '/dosen/submissions'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::store
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:121
+ * @route '/dosen/submissions'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Dosen\SubmissionController::store
+ * @see app/Modules/Fast/Controllers/Dosen/SubmissionController.php:121
+ * @route '/dosen/submissions'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const SubmissionController = { create, store }
 
 export default SubmissionController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Dosen/index.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Dosen/index.ts
@@ -2,12 +2,11 @@ import DashboardController from './DashboardController'
 import SubmissionController from './SubmissionController'
 import HistoryController from './HistoryController'
 import LetterTypeController from './LetterTypeController'
-
 const Dosen = {
     DashboardController: Object.assign(DashboardController, DashboardController),
-    SubmissionController: Object.assign(SubmissionController, SubmissionController),
-    HistoryController: Object.assign(HistoryController, HistoryController),
-    LetterTypeController: Object.assign(LetterTypeController, LetterTypeController),
+SubmissionController: Object.assign(SubmissionController, SubmissionController),
+HistoryController: Object.assign(HistoryController, HistoryController),
+LetterTypeController: Object.assign(LetterTypeController, LetterTypeController),
 }
 
 export default Dosen

--- a/resources/js/actions/App/Modules/Fast/Controllers/Kaprodi/ApprovalController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Kaprodi/ApprovalController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:21
-* @route '/kaprodi/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:24
+ * @route '/kaprodi/dashboard'
+ */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ index.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:21
-* @route '/kaprodi/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:24
+ * @route '/kaprodi/dashboard'
+ */
 index.url = (options?: RouteQueryOptions) => {
     return index.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:21
-* @route '/kaprodi/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:24
+ * @route '/kaprodi/dashboard'
+ */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:21
-* @route '/kaprodi/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:24
+ * @route '/kaprodi/dashboard'
+ */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::index
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:24
+ * @route '/kaprodi/dashboard'
+ */
+    const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::index
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:24
+ * @route '/kaprodi/dashboard'
+ */
+        indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::index
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:24
+ * @route '/kaprodi/dashboard'
+ */
+        indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index.form = indexForm
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:26
-* @route '/kaprodi/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
+ * @route '/kaprodi/antrian'
+ */
 export const queue = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: queue.url(options),
     method: 'get',
@@ -60,38 +94,72 @@ queue.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:26
-* @route '/kaprodi/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
+ * @route '/kaprodi/antrian'
+ */
 queue.url = (options?: RouteQueryOptions) => {
     return queue.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:26
-* @route '/kaprodi/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
+ * @route '/kaprodi/antrian'
+ */
 queue.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: queue.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:26
-* @route '/kaprodi/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
+ * @route '/kaprodi/antrian'
+ */
 queue.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: queue.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::queue
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
+ * @route '/kaprodi/antrian'
+ */
+    const queueForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: queue.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::queue
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
+ * @route '/kaprodi/antrian'
+ */
+        queueForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: queue.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::queue
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
+ * @route '/kaprodi/antrian'
+ */
+        queueForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: queue.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    queue.form = queueForm
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
-* @route '/kaprodi/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:38
+ * @route '/kaprodi/arsip'
+ */
 export const archive = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: archive.url(options),
     method: 'get',
@@ -104,38 +172,72 @@ archive.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
-* @route '/kaprodi/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:38
+ * @route '/kaprodi/arsip'
+ */
 archive.url = (options?: RouteQueryOptions) => {
     return archive.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
-* @route '/kaprodi/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:38
+ * @route '/kaprodi/arsip'
+ */
 archive.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: archive.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:31
-* @route '/kaprodi/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:38
+ * @route '/kaprodi/arsip'
+ */
 archive.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: archive.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::archive
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:38
+ * @route '/kaprodi/arsip'
+ */
+    const archiveForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: archive.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::archive
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:38
+ * @route '/kaprodi/arsip'
+ */
+        archiveForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: archive.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::archive
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:38
+ * @route '/kaprodi/arsip'
+ */
+        archiveForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: archive.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    archive.form = archiveForm
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:41
-* @route '/kaprodi/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:52
+ * @route '/kaprodi/surat/{id}/detail'
+ */
 export const detail = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: detail.url(args, options),
     method: 'get',
@@ -148,25 +250,26 @@ detail.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:41
-* @route '/kaprodi/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:52
+ * @route '/kaprodi/surat/{id}/detail'
+ */
 detail.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return detail.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -175,29 +278,63 @@ detail.url = (args: { id: string | number } | [id: string | number ] | string | 
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:41
-* @route '/kaprodi/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:52
+ * @route '/kaprodi/surat/{id}/detail'
+ */
 detail.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: detail.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:41
-* @route '/kaprodi/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:52
+ * @route '/kaprodi/surat/{id}/detail'
+ */
 detail.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: detail.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::detail
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:52
+ * @route '/kaprodi/surat/{id}/detail'
+ */
+    const detailForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: detail.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::detail
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:52
+ * @route '/kaprodi/surat/{id}/detail'
+ */
+        detailForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: detail.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::detail
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:52
+ * @route '/kaprodi/surat/{id}/detail'
+ */
+        detailForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: detail.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    detail.form = detailForm
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:46
-* @route '/kaprodi/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:60
+ * @route '/kaprodi/surat/{id}'
+ */
 export const show = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
@@ -210,25 +347,26 @@ show.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:46
-* @route '/kaprodi/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:60
+ * @route '/kaprodi/surat/{id}'
+ */
 show.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return show.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -237,29 +375,63 @@ show.url = (args: { id: string | number } | [id: string | number ] | string | nu
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:46
-* @route '/kaprodi/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:60
+ * @route '/kaprodi/surat/{id}'
+ */
 show.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:46
-* @route '/kaprodi/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:60
+ * @route '/kaprodi/surat/{id}'
+ */
 show.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::show
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:60
+ * @route '/kaprodi/surat/{id}'
+ */
+    const showForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::show
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:60
+ * @route '/kaprodi/surat/{id}'
+ */
+        showForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::show
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:60
+ * @route '/kaprodi/surat/{id}'
+ */
+        showForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:51
-* @route '/kaprodi/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:68
+ * @route '/kaprodi/lampiran/{id}/preview'
+ */
 export const previewAttachment = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment.url(args, options),
     method: 'get',
@@ -272,25 +444,26 @@ previewAttachment.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:51
-* @route '/kaprodi/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:68
+ * @route '/kaprodi/lampiran/{id}/preview'
+ */
 previewAttachment.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewAttachment.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -299,29 +472,63 @@ previewAttachment.url = (args: { id: string | number } | [id: string | number ] 
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:51
-* @route '/kaprodi/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:68
+ * @route '/kaprodi/lampiran/{id}/preview'
+ */
 previewAttachment.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:51
-* @route '/kaprodi/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:68
+ * @route '/kaprodi/lampiran/{id}/preview'
+ */
 previewAttachment.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewAttachment.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:68
+ * @route '/kaprodi/lampiran/{id}/preview'
+ */
+    const previewAttachmentForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewAttachment.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:68
+ * @route '/kaprodi/lampiran/{id}/preview'
+ */
+        previewAttachmentForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:68
+ * @route '/kaprodi/lampiran/{id}/preview'
+ */
+        previewAttachmentForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewAttachment.form = previewAttachmentForm
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::approve
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:56
-* @route '/kaprodi/surat/{id}/approve'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:82
+ * @route '/kaprodi/surat/{id}/approve'
+ */
 export const approve = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: approve.url(args, options),
     method: 'post',
@@ -334,25 +541,26 @@ approve.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::approve
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:56
-* @route '/kaprodi/surat/{id}/approve'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:82
+ * @route '/kaprodi/surat/{id}/approve'
+ */
 approve.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return approve.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -361,19 +569,95 @@ approve.url = (args: { id: string | number } | [id: string | number ] | string |
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::approve
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:56
-* @route '/kaprodi/surat/{id}/approve'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:82
+ * @route '/kaprodi/surat/{id}/approve'
+ */
 approve.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: approve.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::approve
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:82
+ * @route '/kaprodi/surat/{id}/approve'
+ */
+    const approveForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: approve.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::approve
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:82
+ * @route '/kaprodi/surat/{id}/approve'
+ */
+        approveForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: approve.url(args, options),
+            method: 'post',
+        })
+    
+    approve.form = approveForm
+/**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:90
+ * @route '/kaprodi/surat/bulk-approve'
+ */
+export const bulkApprove = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove.url(options),
+    method: 'post',
+})
+
+bulkApprove.definition = {
+    methods: ["post"],
+    url: '/kaprodi/surat/bulk-approve',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:90
+ * @route '/kaprodi/surat/bulk-approve'
+ */
+bulkApprove.url = (options?: RouteQueryOptions) => {
+    return bulkApprove.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:90
+ * @route '/kaprodi/surat/bulk-approve'
+ */
+bulkApprove.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:90
+ * @route '/kaprodi/surat/bulk-approve'
+ */
+    const bulkApproveForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: bulkApprove.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:90
+ * @route '/kaprodi/surat/bulk-approve'
+ */
+        bulkApproveForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: bulkApprove.url(options),
+            method: 'post',
+        })
+    
+    bulkApprove.form = bulkApproveForm
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::reject
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:66
-* @route '/kaprodi/surat/{id}/reject'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:120
+ * @route '/kaprodi/surat/{id}/reject'
+ */
 export const reject = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: reject.url(args, options),
     method: 'post',
@@ -386,25 +670,26 @@ reject.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::reject
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:66
-* @route '/kaprodi/surat/{id}/reject'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:120
+ * @route '/kaprodi/surat/{id}/reject'
+ */
 reject.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return reject.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -413,19 +698,40 @@ reject.url = (args: { id: string | number } | [id: string | number ] | string | 
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::reject
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:66
-* @route '/kaprodi/surat/{id}/reject'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:120
+ * @route '/kaprodi/surat/{id}/reject'
+ */
 reject.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: reject.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::reject
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:120
+ * @route '/kaprodi/surat/{id}/reject'
+ */
+    const rejectForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: reject.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::reject
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:120
+ * @route '/kaprodi/surat/{id}/reject'
+ */
+        rejectForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: reject.url(args, options),
+            method: 'post',
+        })
+    
+    reject.form = rejectForm
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::finalReject
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:71
-* @route '/kaprodi/surat/{id}/final-reject'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:128
+ * @route '/kaprodi/surat/{id}/final-reject'
+ */
 export const finalReject = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: finalReject.url(args, options),
     method: 'post',
@@ -438,25 +744,26 @@ finalReject.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::finalReject
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:71
-* @route '/kaprodi/surat/{id}/final-reject'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:128
+ * @route '/kaprodi/surat/{id}/final-reject'
+ */
 finalReject.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return finalReject.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -465,19 +772,40 @@ finalReject.url = (args: { id: string | number } | [id: string | number ] | stri
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::finalReject
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:71
-* @route '/kaprodi/surat/{id}/final-reject'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:128
+ * @route '/kaprodi/surat/{id}/final-reject'
+ */
 finalReject.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: finalReject.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::finalReject
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:128
+ * @route '/kaprodi/surat/{id}/final-reject'
+ */
+    const finalRejectForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: finalReject.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::finalReject
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:128
+ * @route '/kaprodi/surat/{id}/final-reject'
+ */
+        finalRejectForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: finalReject.url(args, options),
+            method: 'post',
+        })
+    
+    finalReject.form = finalRejectForm
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::saveNote
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:61
-* @route '/kaprodi/surat/{id}/note'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:112
+ * @route '/kaprodi/surat/{id}/note'
+ */
 export const saveNote = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: saveNote.url(args, options),
     method: 'post',
@@ -490,25 +818,26 @@ saveNote.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::saveNote
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:61
-* @route '/kaprodi/surat/{id}/note'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:112
+ * @route '/kaprodi/surat/{id}/note'
+ */
 saveNote.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return saveNote.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -517,14 +846,35 @@ saveNote.url = (args: { id: string | number } | [id: string | number ] | string 
 
 /**
 * @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::saveNote
-* @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:61
-* @route '/kaprodi/surat/{id}/note'
-*/
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:112
+ * @route '/kaprodi/surat/{id}/note'
+ */
 saveNote.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: saveNote.url(args, options),
     method: 'post',
 })
 
-const ApprovalController = { index, queue, archive, detail, show, previewAttachment, approve, reject, finalReject, saveNote }
+    /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::saveNote
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:112
+ * @route '/kaprodi/surat/{id}/note'
+ */
+    const saveNoteForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: saveNote.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Kaprodi\ApprovalController::saveNote
+ * @see app/Modules/Fast/Controllers/Kaprodi/ApprovalController.php:112
+ * @route '/kaprodi/surat/{id}/note'
+ */
+        saveNoteForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: saveNote.url(args, options),
+            method: 'post',
+        })
+    
+    saveNote.form = saveNoteForm
+const ApprovalController = { index, queue, archive, detail, show, previewAttachment, approve, bulkApprove, reject, finalReject, saveNote }
 
 export default ApprovalController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Kaprodi/index.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Kaprodi/index.ts
@@ -1,5 +1,4 @@
 import ApprovalController from './ApprovalController'
-
 const Kaprodi = {
     ApprovalController: Object.assign(ApprovalController, ApprovalController),
 }

--- a/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/DashboardController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/DashboardController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
-* @route '/fast/user/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/fast/user/dashboard'
+ */
 const index3f1c8d2b8a2c054e0ec0fbcbc571444d = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index3f1c8d2b8a2c054e0ec0fbcbc571444d.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ index3f1c8d2b8a2c054e0ec0fbcbc571444d.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
-* @route '/fast/user/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/fast/user/dashboard'
+ */
 index3f1c8d2b8a2c054e0ec0fbcbc571444d.url = (options?: RouteQueryOptions) => {
     return index3f1c8d2b8a2c054e0ec0fbcbc571444d.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
-* @route '/fast/user/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/fast/user/dashboard'
+ */
 index3f1c8d2b8a2c054e0ec0fbcbc571444d.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index3f1c8d2b8a2c054e0ec0fbcbc571444d.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
-* @route '/fast/user/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/fast/user/dashboard'
+ */
 index3f1c8d2b8a2c054e0ec0fbcbc571444d.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index3f1c8d2b8a2c054e0ec0fbcbc571444d.url(options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
-* @route '/mahasiswa/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/fast/user/dashboard'
+ */
+    const index3f1c8d2b8a2c054e0ec0fbcbc571444dForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index3f1c8d2b8a2c054e0ec0fbcbc571444d.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/fast/user/dashboard'
+ */
+        index3f1c8d2b8a2c054e0ec0fbcbc571444dForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index3f1c8d2b8a2c054e0ec0fbcbc571444d.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/fast/user/dashboard'
+ */
+        index3f1c8d2b8a2c054e0ec0fbcbc571444dForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index3f1c8d2b8a2c054e0ec0fbcbc571444d.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index3f1c8d2b8a2c054e0ec0fbcbc571444d.form = index3f1c8d2b8a2c054e0ec0fbcbc571444dForm
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/mahasiswa/dashboard'
+ */
 const indexcda560ed7e7d3ddc4bb678606f11ad72 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: indexcda560ed7e7d3ddc4bb678606f11ad72.url(options),
     method: 'get',
@@ -60,32 +94,67 @@ indexcda560ed7e7d3ddc4bb678606f11ad72.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
-* @route '/mahasiswa/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/mahasiswa/dashboard'
+ */
 indexcda560ed7e7d3ddc4bb678606f11ad72.url = (options?: RouteQueryOptions) => {
     return indexcda560ed7e7d3ddc4bb678606f11ad72.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
-* @route '/mahasiswa/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/mahasiswa/dashboard'
+ */
 indexcda560ed7e7d3ddc4bb678606f11ad72.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: indexcda560ed7e7d3ddc4bb678606f11ad72.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
-* @route '/mahasiswa/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/mahasiswa/dashboard'
+ */
 indexcda560ed7e7d3ddc4bb678606f11ad72.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: indexcda560ed7e7d3ddc4bb678606f11ad72.url(options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/mahasiswa/dashboard'
+ */
+    const indexcda560ed7e7d3ddc4bb678606f11ad72Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: indexcda560ed7e7d3ddc4bb678606f11ad72.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/mahasiswa/dashboard'
+ */
+        indexcda560ed7e7d3ddc4bb678606f11ad72Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexcda560ed7e7d3ddc4bb678606f11ad72.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/DashboardController.php:19
+ * @route '/mahasiswa/dashboard'
+ */
+        indexcda560ed7e7d3ddc4bb678606f11ad72Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: indexcda560ed7e7d3ddc4bb678606f11ad72.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    indexcda560ed7e7d3ddc4bb678606f11ad72.form = indexcda560ed7e7d3ddc4bb678606f11ad72Form
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Mahasiswa\DashboardController::index, so this export is a

--- a/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/HistoryController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/HistoryController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:16
-* @route '/fast/user/history'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/fast/user/history'
+ */
 const index87b8947623c11a8e049797a3d2d0f9be = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index87b8947623c11a8e049797a3d2d0f9be.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ index87b8947623c11a8e049797a3d2d0f9be.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:16
-* @route '/fast/user/history'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/fast/user/history'
+ */
 index87b8947623c11a8e049797a3d2d0f9be.url = (options?: RouteQueryOptions) => {
     return index87b8947623c11a8e049797a3d2d0f9be.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:16
-* @route '/fast/user/history'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/fast/user/history'
+ */
 index87b8947623c11a8e049797a3d2d0f9be.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index87b8947623c11a8e049797a3d2d0f9be.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:16
-* @route '/fast/user/history'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/fast/user/history'
+ */
 index87b8947623c11a8e049797a3d2d0f9be.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index87b8947623c11a8e049797a3d2d0f9be.url(options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:16
-* @route '/mahasiswa/history'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/fast/user/history'
+ */
+    const index87b8947623c11a8e049797a3d2d0f9beForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index87b8947623c11a8e049797a3d2d0f9be.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/fast/user/history'
+ */
+        index87b8947623c11a8e049797a3d2d0f9beForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index87b8947623c11a8e049797a3d2d0f9be.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/fast/user/history'
+ */
+        index87b8947623c11a8e049797a3d2d0f9beForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index87b8947623c11a8e049797a3d2d0f9be.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index87b8947623c11a8e049797a3d2d0f9be.form = index87b8947623c11a8e049797a3d2d0f9beForm
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/mahasiswa/history'
+ */
 const index5a4c493418e0df1b409be4699ee669dc = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index5a4c493418e0df1b409be4699ee669dc.url(options),
     method: 'get',
@@ -60,32 +94,67 @@ index5a4c493418e0df1b409be4699ee669dc.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:16
-* @route '/mahasiswa/history'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/mahasiswa/history'
+ */
 index5a4c493418e0df1b409be4699ee669dc.url = (options?: RouteQueryOptions) => {
     return index5a4c493418e0df1b409be4699ee669dc.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:16
-* @route '/mahasiswa/history'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/mahasiswa/history'
+ */
 index5a4c493418e0df1b409be4699ee669dc.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index5a4c493418e0df1b409be4699ee669dc.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:16
-* @route '/mahasiswa/history'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/mahasiswa/history'
+ */
 index5a4c493418e0df1b409be4699ee669dc.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index5a4c493418e0df1b409be4699ee669dc.url(options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/mahasiswa/history'
+ */
+    const index5a4c493418e0df1b409be4699ee669dcForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index5a4c493418e0df1b409be4699ee669dc.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/mahasiswa/history'
+ */
+        index5a4c493418e0df1b409be4699ee669dcForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index5a4c493418e0df1b409be4699ee669dc.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:17
+ * @route '/mahasiswa/history'
+ */
+        index5a4c493418e0df1b409be4699ee669dcForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index5a4c493418e0df1b409be4699ee669dc.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index5a4c493418e0df1b409be4699ee669dc.form = index5a4c493418e0df1b409be4699ee669dcForm
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::index, so this export is a
@@ -99,9 +168,9 @@ export const index = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:53
-* @route '/fast/user/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/fast/user/history/{id}'
+ */
 const show9da74bc9fc8d8ed90070357bf01c09d8 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show9da74bc9fc8d8ed90070357bf01c09d8.url(args, options),
     method: 'get',
@@ -114,25 +183,26 @@ show9da74bc9fc8d8ed90070357bf01c09d8.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:53
-* @route '/fast/user/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/fast/user/history/{id}'
+ */
 show9da74bc9fc8d8ed90070357bf01c09d8.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return show9da74bc9fc8d8ed90070357bf01c09d8.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -141,29 +211,63 @@ show9da74bc9fc8d8ed90070357bf01c09d8.url = (args: { id: string | number } | [id:
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:53
-* @route '/fast/user/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/fast/user/history/{id}'
+ */
 show9da74bc9fc8d8ed90070357bf01c09d8.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show9da74bc9fc8d8ed90070357bf01c09d8.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:53
-* @route '/fast/user/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/fast/user/history/{id}'
+ */
 show9da74bc9fc8d8ed90070357bf01c09d8.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show9da74bc9fc8d8ed90070357bf01c09d8.url(args, options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:53
-* @route '/mahasiswa/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/fast/user/history/{id}'
+ */
+    const show9da74bc9fc8d8ed90070357bf01c09d8Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show9da74bc9fc8d8ed90070357bf01c09d8.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/fast/user/history/{id}'
+ */
+        show9da74bc9fc8d8ed90070357bf01c09d8Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show9da74bc9fc8d8ed90070357bf01c09d8.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/fast/user/history/{id}'
+ */
+        show9da74bc9fc8d8ed90070357bf01c09d8Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show9da74bc9fc8d8ed90070357bf01c09d8.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show9da74bc9fc8d8ed90070357bf01c09d8.form = show9da74bc9fc8d8ed90070357bf01c09d8Form
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/mahasiswa/history/{id}'
+ */
 const show26c38b6c2e007262af1ec1ea4b164d97 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show26c38b6c2e007262af1ec1ea4b164d97.url(args, options),
     method: 'get',
@@ -176,25 +280,26 @@ show26c38b6c2e007262af1ec1ea4b164d97.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:53
-* @route '/mahasiswa/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/mahasiswa/history/{id}'
+ */
 show26c38b6c2e007262af1ec1ea4b164d97.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return show26c38b6c2e007262af1ec1ea4b164d97.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -203,23 +308,58 @@ show26c38b6c2e007262af1ec1ea4b164d97.url = (args: { id: string | number } | [id:
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:53
-* @route '/mahasiswa/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/mahasiswa/history/{id}'
+ */
 show26c38b6c2e007262af1ec1ea4b164d97.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show26c38b6c2e007262af1ec1ea4b164d97.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:53
-* @route '/mahasiswa/history/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/mahasiswa/history/{id}'
+ */
 show26c38b6c2e007262af1ec1ea4b164d97.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show26c38b6c2e007262af1ec1ea4b164d97.url(args, options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/mahasiswa/history/{id}'
+ */
+    const show26c38b6c2e007262af1ec1ea4b164d97Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show26c38b6c2e007262af1ec1ea4b164d97.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/mahasiswa/history/{id}'
+ */
+        show26c38b6c2e007262af1ec1ea4b164d97Form.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show26c38b6c2e007262af1ec1ea4b164d97.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:75
+ * @route '/mahasiswa/history/{id}'
+ */
+        show26c38b6c2e007262af1ec1ea4b164d97Form.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show26c38b6c2e007262af1ec1ea4b164d97.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show26c38b6c2e007262af1ec1ea4b164d97.form = show26c38b6c2e007262af1ec1ea4b164d97Form
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::show, so this export is a
@@ -233,9 +373,9 @@ export const show = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:178
-* @route '/fast/user/surat/{id}/cancel'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/fast/user/surat/{id}/cancel'
+ */
 const cancel74bd7e97928c58b44e953de9068b8404 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: cancel74bd7e97928c58b44e953de9068b8404.url(args, options),
     method: 'post',
@@ -248,25 +388,26 @@ cancel74bd7e97928c58b44e953de9068b8404.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:178
-* @route '/fast/user/surat/{id}/cancel'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/fast/user/surat/{id}/cancel'
+ */
 cancel74bd7e97928c58b44e953de9068b8404.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return cancel74bd7e97928c58b44e953de9068b8404.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -275,19 +416,40 @@ cancel74bd7e97928c58b44e953de9068b8404.url = (args: { id: string | number } | [i
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:178
-* @route '/fast/user/surat/{id}/cancel'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/fast/user/surat/{id}/cancel'
+ */
 cancel74bd7e97928c58b44e953de9068b8404.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: cancel74bd7e97928c58b44e953de9068b8404.url(args, options),
     method: 'post',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:178
-* @route '/mahasiswa/surat/{id}/cancel'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/fast/user/surat/{id}/cancel'
+ */
+    const cancel74bd7e97928c58b44e953de9068b8404Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: cancel74bd7e97928c58b44e953de9068b8404.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/fast/user/surat/{id}/cancel'
+ */
+        cancel74bd7e97928c58b44e953de9068b8404Form.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: cancel74bd7e97928c58b44e953de9068b8404.url(args, options),
+            method: 'post',
+        })
+    
+    cancel74bd7e97928c58b44e953de9068b8404.form = cancel74bd7e97928c58b44e953de9068b8404Form
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/mahasiswa/surat/{id}/cancel'
+ */
 const canceldf32884bde61aadf9b6523269bf53f90 = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: canceldf32884bde61aadf9b6523269bf53f90.url(args, options),
     method: 'post',
@@ -300,25 +462,26 @@ canceldf32884bde61aadf9b6523269bf53f90.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:178
-* @route '/mahasiswa/surat/{id}/cancel'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/mahasiswa/surat/{id}/cancel'
+ */
 canceldf32884bde61aadf9b6523269bf53f90.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return canceldf32884bde61aadf9b6523269bf53f90.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -327,13 +490,35 @@ canceldf32884bde61aadf9b6523269bf53f90.url = (args: { id: string | number } | [i
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
-* @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:178
-* @route '/mahasiswa/surat/{id}/cancel'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/mahasiswa/surat/{id}/cancel'
+ */
 canceldf32884bde61aadf9b6523269bf53f90.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: canceldf32884bde61aadf9b6523269bf53f90.url(args, options),
     method: 'post',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/mahasiswa/surat/{id}/cancel'
+ */
+    const canceldf32884bde61aadf9b6523269bf53f90Form = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: canceldf32884bde61aadf9b6523269bf53f90.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel
+ * @see app/Modules/Fast/Controllers/Mahasiswa/HistoryController.php:217
+ * @route '/mahasiswa/surat/{id}/cancel'
+ */
+        canceldf32884bde61aadf9b6523269bf53f90Form.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: canceldf32884bde61aadf9b6523269bf53f90.url(args, options),
+            method: 'post',
+        })
+    
+    canceldf32884bde61aadf9b6523269bf53f90.form = canceldf32884bde61aadf9b6523269bf53f90Form
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Mahasiswa\HistoryController::cancel, so this export is a

--- a/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\LetterTypeController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
-* @route '/jenis-surat/{jenisSurat}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
+ * @route '/jenis-surat/{jenisSurat}'
+ */
 export const show = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
@@ -16,31 +16,31 @@ show.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\LetterTypeController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
-* @route '/jenis-surat/{jenisSurat}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
+ * @route '/jenis-surat/{jenisSurat}'
+ */
 show.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { jenisSurat: args }
     }
 
-    if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
-        args = { jenisSurat: args.id }
-    }
-
+            if (typeof args === 'object' && !Array.isArray(args) && 'id' in args) {
+            args = { jenisSurat: args.id }
+        }
+    
     if (Array.isArray(args)) {
         args = {
-            jenisSurat: args[0],
-        }
+                    jenisSurat: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        jenisSurat: typeof args.jenisSurat === 'object'
-        ? args.jenisSurat.id
-        : args.jenisSurat,
-    }
+                        jenisSurat: typeof args.jenisSurat === 'object'
+                ? args.jenisSurat.id
+                : args.jenisSurat,
+                }
 
     return show.definition.url
             .replace('{jenisSurat}', parsedArgs.jenisSurat.toString())
@@ -49,24 +49,58 @@ show.url = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number 
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\LetterTypeController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
-* @route '/jenis-surat/{jenisSurat}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
+ * @route '/jenis-surat/{jenisSurat}'
+ */
 show.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\LetterTypeController::show
-* @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
-* @route '/jenis-surat/{jenisSurat}'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
+ * @route '/jenis-surat/{jenisSurat}'
+ */
 show.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\LetterTypeController::show
+ * @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
+ * @route '/jenis-surat/{jenisSurat}'
+ */
+    const showForm = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\LetterTypeController::show
+ * @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
+ * @route '/jenis-surat/{jenisSurat}'
+ */
+        showForm.get = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\LetterTypeController::show
+ * @see app/Modules/Fast/Controllers/Mahasiswa/LetterTypeController.php:13
+ * @route '/jenis-surat/{jenisSurat}'
+ */
+        showForm.head = (args: { jenisSurat: number | { id: number } } | [jenisSurat: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 const LetterTypeController = { show }
 
 export default LetterTypeController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/SubmissionController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/SubmissionController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
-* @route '/fast/user/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/fast/user/ajukan'
+ */
 const create92801d7540bdfe071e00b64abeede393 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create92801d7540bdfe071e00b64abeede393.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ create92801d7540bdfe071e00b64abeede393.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
-* @route '/fast/user/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/fast/user/ajukan'
+ */
 create92801d7540bdfe071e00b64abeede393.url = (options?: RouteQueryOptions) => {
     return create92801d7540bdfe071e00b64abeede393.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
-* @route '/fast/user/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/fast/user/ajukan'
+ */
 create92801d7540bdfe071e00b64abeede393.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create92801d7540bdfe071e00b64abeede393.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
-* @route '/fast/user/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/fast/user/ajukan'
+ */
 create92801d7540bdfe071e00b64abeede393.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: create92801d7540bdfe071e00b64abeede393.url(options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
-* @route '/mahasiswa/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/fast/user/ajukan'
+ */
+    const create92801d7540bdfe071e00b64abeede393Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: create92801d7540bdfe071e00b64abeede393.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/fast/user/ajukan'
+ */
+        create92801d7540bdfe071e00b64abeede393Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create92801d7540bdfe071e00b64abeede393.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/fast/user/ajukan'
+ */
+        create92801d7540bdfe071e00b64abeede393Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create92801d7540bdfe071e00b64abeede393.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    create92801d7540bdfe071e00b64abeede393.form = create92801d7540bdfe071e00b64abeede393Form
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/mahasiswa/ajukan'
+ */
 const create02d423413b9e77609d83f7fc6e747101 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create02d423413b9e77609d83f7fc6e747101.url(options),
     method: 'get',
@@ -60,32 +94,67 @@ create02d423413b9e77609d83f7fc6e747101.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
-* @route '/mahasiswa/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/mahasiswa/ajukan'
+ */
 create02d423413b9e77609d83f7fc6e747101.url = (options?: RouteQueryOptions) => {
     return create02d423413b9e77609d83f7fc6e747101.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
-* @route '/mahasiswa/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/mahasiswa/ajukan'
+ */
 create02d423413b9e77609d83f7fc6e747101.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create02d423413b9e77609d83f7fc6e747101.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
-* @route '/mahasiswa/ajukan'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/mahasiswa/ajukan'
+ */
 create02d423413b9e77609d83f7fc6e747101.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: create02d423413b9e77609d83f7fc6e747101.url(options),
     method: 'head',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/mahasiswa/ajukan'
+ */
+    const create02d423413b9e77609d83f7fc6e747101Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: create02d423413b9e77609d83f7fc6e747101.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/mahasiswa/ajukan'
+ */
+        create02d423413b9e77609d83f7fc6e747101Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create02d423413b9e77609d83f7fc6e747101.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:28
+ * @route '/mahasiswa/ajukan'
+ */
+        create02d423413b9e77609d83f7fc6e747101Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create02d423413b9e77609d83f7fc6e747101.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    create02d423413b9e77609d83f7fc6e747101.form = create02d423413b9e77609d83f7fc6e747101Form
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::create, so this export is a
@@ -99,9 +168,9 @@ export const create = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:120
-* @route '/fast/user/submissions'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/fast/user/submissions'
+ */
 const storefa8f1b7ec6e51ab02156722b8385a8d5 = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: storefa8f1b7ec6e51ab02156722b8385a8d5.url(options),
     method: 'post',
@@ -114,28 +183,49 @@ storefa8f1b7ec6e51ab02156722b8385a8d5.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:120
-* @route '/fast/user/submissions'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/fast/user/submissions'
+ */
 storefa8f1b7ec6e51ab02156722b8385a8d5.url = (options?: RouteQueryOptions) => {
     return storefa8f1b7ec6e51ab02156722b8385a8d5.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:120
-* @route '/fast/user/submissions'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/fast/user/submissions'
+ */
 storefa8f1b7ec6e51ab02156722b8385a8d5.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: storefa8f1b7ec6e51ab02156722b8385a8d5.url(options),
     method: 'post',
 })
 
-/**
+    /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:120
-* @route '/mahasiswa/submissions'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/fast/user/submissions'
+ */
+    const storefa8f1b7ec6e51ab02156722b8385a8d5Form = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: storefa8f1b7ec6e51ab02156722b8385a8d5.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/fast/user/submissions'
+ */
+        storefa8f1b7ec6e51ab02156722b8385a8d5Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: storefa8f1b7ec6e51ab02156722b8385a8d5.url(options),
+            method: 'post',
+        })
+    
+    storefa8f1b7ec6e51ab02156722b8385a8d5.form = storefa8f1b7ec6e51ab02156722b8385a8d5Form
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/mahasiswa/submissions'
+ */
 const storea3ef875fdb8283f578a11a3e7e42104d = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: storea3ef875fdb8283f578a11a3e7e42104d.url(options),
     method: 'post',
@@ -148,22 +238,44 @@ storea3ef875fdb8283f578a11a3e7e42104d.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:120
-* @route '/mahasiswa/submissions'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/mahasiswa/submissions'
+ */
 storea3ef875fdb8283f578a11a3e7e42104d.url = (options?: RouteQueryOptions) => {
     return storea3ef875fdb8283f578a11a3e7e42104d.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
-* @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:120
-* @route '/mahasiswa/submissions'
-*/
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/mahasiswa/submissions'
+ */
 storea3ef875fdb8283f578a11a3e7e42104d.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: storea3ef875fdb8283f578a11a3e7e42104d.url(options),
     method: 'post',
 })
+
+    /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/mahasiswa/submissions'
+ */
+    const storea3ef875fdb8283f578a11a3e7e42104dForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: storea3ef875fdb8283f578a11a3e7e42104d.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store
+ * @see app/Modules/Fast/Controllers/Mahasiswa/SubmissionController.php:121
+ * @route '/mahasiswa/submissions'
+ */
+        storea3ef875fdb8283f578a11a3e7e42104dForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: storea3ef875fdb8283f578a11a3e7e42104d.url(options),
+            method: 'post',
+        })
+    
+    storea3ef875fdb8283f578a11a3e7e42104d.form = storea3ef875fdb8283f578a11a3e7e42104dForm
 
 /**
 * Multiple routes resolve to \App\Modules\Fast\Controllers\Mahasiswa\SubmissionController::store, so this export is a

--- a/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/index.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Mahasiswa/index.ts
@@ -2,12 +2,11 @@ import DashboardController from './DashboardController'
 import SubmissionController from './SubmissionController'
 import HistoryController from './HistoryController'
 import LetterTypeController from './LetterTypeController'
-
 const Mahasiswa = {
     DashboardController: Object.assign(DashboardController, DashboardController),
-    SubmissionController: Object.assign(SubmissionController, SubmissionController),
-    HistoryController: Object.assign(HistoryController, HistoryController),
-    LetterTypeController: Object.assign(LetterTypeController, LetterTypeController),
+SubmissionController: Object.assign(SubmissionController, SubmissionController),
+HistoryController: Object.assign(HistoryController, HistoryController),
+LetterTypeController: Object.assign(LetterTypeController, LetterTypeController),
 }
 
 export default Mahasiswa

--- a/resources/js/actions/App/Modules/Fast/Controllers/Shared/Approval/ApprovalController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Shared/Approval/ApprovalController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:21
-* @route '/approval/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:24
+ * @route '/approval/dashboard'
+ */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ index.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:21
-* @route '/approval/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:24
+ * @route '/approval/dashboard'
+ */
 index.url = (options?: RouteQueryOptions) => {
     return index.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:21
-* @route '/approval/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:24
+ * @route '/approval/dashboard'
+ */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::index
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:21
-* @route '/approval/dashboard'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:24
+ * @route '/approval/dashboard'
+ */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::index
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:24
+ * @route '/approval/dashboard'
+ */
+    const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::index
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:24
+ * @route '/approval/dashboard'
+ */
+        indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::index
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:24
+ * @route '/approval/dashboard'
+ */
+        indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index.form = indexForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:26
-* @route '/approval/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
+ * @route '/approval/antrian'
+ */
 export const queue = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: queue.url(options),
     method: 'get',
@@ -60,38 +94,72 @@ queue.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:26
-* @route '/approval/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
+ * @route '/approval/antrian'
+ */
 queue.url = (options?: RouteQueryOptions) => {
     return queue.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:26
-* @route '/approval/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
+ * @route '/approval/antrian'
+ */
 queue.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: queue.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::queue
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:26
-* @route '/approval/antrian'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
+ * @route '/approval/antrian'
+ */
 queue.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: queue.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::queue
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
+ * @route '/approval/antrian'
+ */
+    const queueForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: queue.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::queue
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
+ * @route '/approval/antrian'
+ */
+        queueForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: queue.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::queue
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
+ * @route '/approval/antrian'
+ */
+        queueForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: queue.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    queue.form = queueForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
-* @route '/approval/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:38
+ * @route '/approval/arsip'
+ */
 export const archive = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: archive.url(options),
     method: 'get',
@@ -104,38 +172,72 @@ archive.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
-* @route '/approval/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:38
+ * @route '/approval/arsip'
+ */
 archive.url = (options?: RouteQueryOptions) => {
     return archive.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
-* @route '/approval/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:38
+ * @route '/approval/arsip'
+ */
 archive.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: archive.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::archive
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:31
-* @route '/approval/arsip'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:38
+ * @route '/approval/arsip'
+ */
 archive.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: archive.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::archive
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:38
+ * @route '/approval/arsip'
+ */
+    const archiveForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: archive.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::archive
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:38
+ * @route '/approval/arsip'
+ */
+        archiveForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: archive.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::archive
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:38
+ * @route '/approval/arsip'
+ */
+        archiveForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: archive.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    archive.form = archiveForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:41
-* @route '/approval/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:52
+ * @route '/approval/surat/{id}/detail'
+ */
 export const detail = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: detail.url(args, options),
     method: 'get',
@@ -148,25 +250,26 @@ detail.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:41
-* @route '/approval/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:52
+ * @route '/approval/surat/{id}/detail'
+ */
 detail.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return detail.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -175,29 +278,63 @@ detail.url = (args: { id: string | number } | [id: string | number ] | string | 
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:41
-* @route '/approval/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:52
+ * @route '/approval/surat/{id}/detail'
+ */
 detail.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: detail.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::detail
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:41
-* @route '/approval/surat/{id}/detail'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:52
+ * @route '/approval/surat/{id}/detail'
+ */
 detail.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: detail.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::detail
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:52
+ * @route '/approval/surat/{id}/detail'
+ */
+    const detailForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: detail.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::detail
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:52
+ * @route '/approval/surat/{id}/detail'
+ */
+        detailForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: detail.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::detail
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:52
+ * @route '/approval/surat/{id}/detail'
+ */
+        detailForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: detail.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    detail.form = detailForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:46
-* @route '/approval/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:60
+ * @route '/approval/surat/{id}'
+ */
 export const show = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
@@ -210,25 +347,26 @@ show.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:46
-* @route '/approval/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:60
+ * @route '/approval/surat/{id}'
+ */
 show.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return show.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -237,29 +375,63 @@ show.url = (args: { id: string | number } | [id: string | number ] | string | nu
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:46
-* @route '/approval/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:60
+ * @route '/approval/surat/{id}'
+ */
 show.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::show
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:46
-* @route '/approval/surat/{id}'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:60
+ * @route '/approval/surat/{id}'
+ */
 show.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::show
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:60
+ * @route '/approval/surat/{id}'
+ */
+    const showForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::show
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:60
+ * @route '/approval/surat/{id}'
+ */
+        showForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::show
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:60
+ * @route '/approval/surat/{id}'
+ */
+        showForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:51
-* @route '/approval/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:68
+ * @route '/approval/lampiran/{id}/preview'
+ */
 export const previewAttachment = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment.url(args, options),
     method: 'get',
@@ -272,25 +444,26 @@ previewAttachment.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:51
-* @route '/approval/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:68
+ * @route '/approval/lampiran/{id}/preview'
+ */
 previewAttachment.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return previewAttachment.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -299,29 +472,63 @@ previewAttachment.url = (args: { id: string | number } | [id: string | number ] 
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:51
-* @route '/approval/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:68
+ * @route '/approval/lampiran/{id}/preview'
+ */
 previewAttachment.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: previewAttachment.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::previewAttachment
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:51
-* @route '/approval/lampiran/{id}/preview'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:68
+ * @route '/approval/lampiran/{id}/preview'
+ */
 previewAttachment.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: previewAttachment.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:68
+ * @route '/approval/lampiran/{id}/preview'
+ */
+    const previewAttachmentForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: previewAttachment.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:68
+ * @route '/approval/lampiran/{id}/preview'
+ */
+        previewAttachmentForm.get = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::previewAttachment
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:68
+ * @route '/approval/lampiran/{id}/preview'
+ */
+        previewAttachmentForm.head = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: previewAttachment.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    previewAttachment.form = previewAttachmentForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::approve
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:56
-* @route '/approval/surat/{id}/approve'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:82
+ * @route '/approval/surat/{id}/approve'
+ */
 export const approve = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: approve.url(args, options),
     method: 'post',
@@ -334,25 +541,26 @@ approve.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::approve
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:56
-* @route '/approval/surat/{id}/approve'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:82
+ * @route '/approval/surat/{id}/approve'
+ */
 approve.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return approve.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -361,19 +569,95 @@ approve.url = (args: { id: string | number } | [id: string | number ] | string |
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::approve
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:56
-* @route '/approval/surat/{id}/approve'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:82
+ * @route '/approval/surat/{id}/approve'
+ */
 approve.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: approve.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::approve
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:82
+ * @route '/approval/surat/{id}/approve'
+ */
+    const approveForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: approve.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::approve
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:82
+ * @route '/approval/surat/{id}/approve'
+ */
+        approveForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: approve.url(args, options),
+            method: 'post',
+        })
+    
+    approve.form = approveForm
+/**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:90
+ * @route '/approval/surat/bulk-approve'
+ */
+export const bulkApprove = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove.url(options),
+    method: 'post',
+})
+
+bulkApprove.definition = {
+    methods: ["post"],
+    url: '/approval/surat/bulk-approve',
+} satisfies RouteDefinition<["post"]>
+
+/**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:90
+ * @route '/approval/surat/bulk-approve'
+ */
+bulkApprove.url = (options?: RouteQueryOptions) => {
+    return bulkApprove.definition.url + queryParams(options)
+}
+
+/**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:90
+ * @route '/approval/surat/bulk-approve'
+ */
+bulkApprove.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: bulkApprove.url(options),
+    method: 'post',
+})
+
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:90
+ * @route '/approval/surat/bulk-approve'
+ */
+    const bulkApproveForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: bulkApprove.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::bulkApprove
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:90
+ * @route '/approval/surat/bulk-approve'
+ */
+        bulkApproveForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: bulkApprove.url(options),
+            method: 'post',
+        })
+    
+    bulkApprove.form = bulkApproveForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::reject
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:66
-* @route '/approval/surat/{id}/reject'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:120
+ * @route '/approval/surat/{id}/reject'
+ */
 export const reject = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: reject.url(args, options),
     method: 'post',
@@ -386,25 +670,26 @@ reject.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::reject
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:66
-* @route '/approval/surat/{id}/reject'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:120
+ * @route '/approval/surat/{id}/reject'
+ */
 reject.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return reject.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -413,19 +698,40 @@ reject.url = (args: { id: string | number } | [id: string | number ] | string | 
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::reject
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:66
-* @route '/approval/surat/{id}/reject'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:120
+ * @route '/approval/surat/{id}/reject'
+ */
 reject.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: reject.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::reject
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:120
+ * @route '/approval/surat/{id}/reject'
+ */
+    const rejectForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: reject.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::reject
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:120
+ * @route '/approval/surat/{id}/reject'
+ */
+        rejectForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: reject.url(args, options),
+            method: 'post',
+        })
+    
+    reject.form = rejectForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::finalReject
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:71
-* @route '/approval/surat/{id}/final-reject'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:128
+ * @route '/approval/surat/{id}/final-reject'
+ */
 export const finalReject = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: finalReject.url(args, options),
     method: 'post',
@@ -438,25 +744,26 @@ finalReject.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::finalReject
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:71
-* @route '/approval/surat/{id}/final-reject'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:128
+ * @route '/approval/surat/{id}/final-reject'
+ */
 finalReject.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return finalReject.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -465,19 +772,40 @@ finalReject.url = (args: { id: string | number } | [id: string | number ] | stri
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::finalReject
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:71
-* @route '/approval/surat/{id}/final-reject'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:128
+ * @route '/approval/surat/{id}/final-reject'
+ */
 finalReject.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: finalReject.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::finalReject
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:128
+ * @route '/approval/surat/{id}/final-reject'
+ */
+    const finalRejectForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: finalReject.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::finalReject
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:128
+ * @route '/approval/surat/{id}/final-reject'
+ */
+        finalRejectForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: finalReject.url(args, options),
+            method: 'post',
+        })
+    
+    finalReject.form = finalRejectForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::saveNote
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:61
-* @route '/approval/surat/{id}/note'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:112
+ * @route '/approval/surat/{id}/note'
+ */
 export const saveNote = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: saveNote.url(args, options),
     method: 'post',
@@ -490,25 +818,26 @@ saveNote.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::saveNote
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:61
-* @route '/approval/surat/{id}/note'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:112
+ * @route '/approval/surat/{id}/note'
+ */
 saveNote.url = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { id: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            id: args[0],
-        }
+                    id: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        id: args.id,
-    }
+                        id: args.id,
+                }
 
     return saveNote.definition.url
             .replace('{id}', parsedArgs.id.toString())
@@ -517,14 +846,35 @@ saveNote.url = (args: { id: string | number } | [id: string | number ] | string 
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::saveNote
-* @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:61
-* @route '/approval/surat/{id}/note'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:112
+ * @route '/approval/surat/{id}/note'
+ */
 saveNote.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: saveNote.url(args, options),
     method: 'post',
 })
 
-const ApprovalController = { index, queue, archive, detail, show, previewAttachment, approve, reject, finalReject, saveNote }
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::saveNote
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:112
+ * @route '/approval/surat/{id}/note'
+ */
+    const saveNoteForm = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: saveNote.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\Approval\ApprovalController::saveNote
+ * @see app/Modules/Fast/Controllers/Shared/Approval/ApprovalController.php:112
+ * @route '/approval/surat/{id}/note'
+ */
+        saveNoteForm.post = (args: { id: string | number } | [id: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: saveNote.url(args, options),
+            method: 'post',
+        })
+    
+    saveNote.form = saveNoteForm
+const ApprovalController = { index, queue, archive, detail, show, previewAttachment, approve, bulkApprove, reject, finalReject, saveNote }
 
 export default ApprovalController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Shared/Approval/index.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Shared/Approval/index.ts
@@ -1,5 +1,4 @@
 import ApprovalController from './ApprovalController'
-
 const Approval = {
     ApprovalController: Object.assign(ApprovalController, ApprovalController),
 }

--- a/resources/js/actions/App/Modules/Fast/Controllers/Shared/NotificationController.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Shared/NotificationController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../../wayfinder'
 /**
 * @see \App\Modules\Fast\Controllers\Shared\NotificationController::read
-* @see app/Modules/Fast/Controllers/Shared/NotificationController.php:15
-* @route '/notifications/{notificationId}/read'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:22
+ * @route '/notifications/{notificationId}/read'
+ */
 export const read = (args: { notificationId: string | number } | [notificationId: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: read.url(args, options),
     method: 'post',
@@ -16,25 +16,26 @@ read.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\NotificationController::read
-* @see app/Modules/Fast/Controllers/Shared/NotificationController.php:15
-* @route '/notifications/{notificationId}/read'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:22
+ * @route '/notifications/{notificationId}/read'
+ */
 read.url = (args: { notificationId: string | number } | [notificationId: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { notificationId: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            notificationId: args[0],
-        }
+                    notificationId: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        notificationId: args.notificationId,
-    }
+                        notificationId: args.notificationId,
+                }
 
     return read.definition.url
             .replace('{notificationId}', parsedArgs.notificationId.toString())
@@ -43,19 +44,40 @@ read.url = (args: { notificationId: string | number } | [notificationId: string 
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\NotificationController::read
-* @see app/Modules/Fast/Controllers/Shared/NotificationController.php:15
-* @route '/notifications/{notificationId}/read'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:22
+ * @route '/notifications/{notificationId}/read'
+ */
 read.post = (args: { notificationId: string | number } | [notificationId: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: read.url(args, options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\NotificationController::read
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:22
+ * @route '/notifications/{notificationId}/read'
+ */
+    const readForm = (args: { notificationId: string | number } | [notificationId: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: read.url(args, options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\NotificationController::read
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:22
+ * @route '/notifications/{notificationId}/read'
+ */
+        readForm.post = (args: { notificationId: string | number } | [notificationId: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: read.url(args, options),
+            method: 'post',
+        })
+    
+    read.form = readForm
 /**
 * @see \App\Modules\Fast\Controllers\Shared\NotificationController::readAll
-* @see app/Modules/Fast/Controllers/Shared/NotificationController.php:39
-* @route '/notifications/read-all'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:50
+ * @route '/notifications/read-all'
+ */
 export const readAll = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: readAll.url(options),
     method: 'post',
@@ -68,23 +90,44 @@ readAll.definition = {
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\NotificationController::readAll
-* @see app/Modules/Fast/Controllers/Shared/NotificationController.php:39
-* @route '/notifications/read-all'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:50
+ * @route '/notifications/read-all'
+ */
 readAll.url = (options?: RouteQueryOptions) => {
     return readAll.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Fast\Controllers\Shared\NotificationController::readAll
-* @see app/Modules/Fast/Controllers/Shared/NotificationController.php:39
-* @route '/notifications/read-all'
-*/
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:50
+ * @route '/notifications/read-all'
+ */
 readAll.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: readAll.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Fast\Controllers\Shared\NotificationController::readAll
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:50
+ * @route '/notifications/read-all'
+ */
+    const readAllForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: readAll.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Fast\Controllers\Shared\NotificationController::readAll
+ * @see app/Modules/Fast/Controllers/Shared/NotificationController.php:50
+ * @route '/notifications/read-all'
+ */
+        readAllForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: readAll.url(options),
+            method: 'post',
+        })
+    
+    readAll.form = readAllForm
 const NotificationController = { read, readAll }
 
 export default NotificationController

--- a/resources/js/actions/App/Modules/Fast/Controllers/Shared/index.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/Shared/index.ts
@@ -1,9 +1,8 @@
 import NotificationController from './NotificationController'
 import Approval from './Approval'
-
 const Shared = {
     NotificationController: Object.assign(NotificationController, NotificationController),
-    Approval: Object.assign(Approval, Approval),
+Approval: Object.assign(Approval, Approval),
 }
 
 export default Shared

--- a/resources/js/actions/App/Modules/Fast/Controllers/index.ts
+++ b/resources/js/actions/App/Modules/Fast/Controllers/index.ts
@@ -4,14 +4,13 @@ import Mahasiswa from './Mahasiswa'
 import Dosen from './Dosen'
 import Kaprodi from './Kaprodi'
 import Dekan from './Dekan'
-
 const Controllers = {
     Admin: Object.assign(Admin, Admin),
-    Shared: Object.assign(Shared, Shared),
-    Mahasiswa: Object.assign(Mahasiswa, Mahasiswa),
-    Dosen: Object.assign(Dosen, Dosen),
-    Kaprodi: Object.assign(Kaprodi, Kaprodi),
-    Dekan: Object.assign(Dekan, Dekan),
+Shared: Object.assign(Shared, Shared),
+Mahasiswa: Object.assign(Mahasiswa, Mahasiswa),
+Dosen: Object.assign(Dosen, Dosen),
+Kaprodi: Object.assign(Kaprodi, Kaprodi),
+Dekan: Object.assign(Dekan, Dekan),
 }
 
 export default Controllers

--- a/resources/js/actions/App/Modules/Fast/index.ts
+++ b/resources/js/actions/App/Modules/Fast/index.ts
@@ -1,5 +1,4 @@
 import Controllers from './Controllers'
-
 const Fast = {
     Controllers: Object.assign(Controllers, Controllers),
 }

--- a/resources/js/actions/App/Modules/Settings/Controllers/SecurityController.ts
+++ b/resources/js/actions/App/Modules/Settings/Controllers/SecurityController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::edit
-* @see app/Modules/Settings/Controllers/SecurityController.php:38
-* @route '/settings/security'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
 export const edit = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ edit.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::edit
-* @see app/Modules/Settings/Controllers/SecurityController.php:38
-* @route '/settings/security'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
 edit.url = (options?: RouteQueryOptions) => {
     return edit.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::edit
-* @see app/Modules/Settings/Controllers/SecurityController.php:38
-* @route '/settings/security'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
 edit.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::edit
-* @see app/Modules/Settings/Controllers/SecurityController.php:38
-* @route '/settings/security'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
 edit.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: edit.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\SecurityController::edit
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
+    const editForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: edit.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\SecurityController::edit
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
+        editForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Settings\Controllers\SecurityController::edit
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
+        editForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    edit.form = editForm
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::update
-* @see app/Modules/Settings/Controllers/SecurityController.php:72
-* @route '/settings/password'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
 export const update = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(options),
     method: 'put',
@@ -60,28 +94,59 @@ update.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::update
-* @see app/Modules/Settings/Controllers/SecurityController.php:72
-* @route '/settings/password'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
 update.url = (options?: RouteQueryOptions) => {
     return update.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::update
-* @see app/Modules/Settings/Controllers/SecurityController.php:72
-* @route '/settings/password'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
 update.put = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(options),
     method: 'put',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\SecurityController::update
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
+    const updateForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update.url({
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\SecurityController::update
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
+        updateForm.put = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update.form = updateForm
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::updateEmail
-* @see app/Modules/Settings/Controllers/SecurityController.php:94
-* @route '/settings/email'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:94
+ * @route '/settings/email'
+ */
 export const updateEmail = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: updateEmail.url(options),
     method: 'put',
@@ -94,23 +159,54 @@ updateEmail.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::updateEmail
-* @see app/Modules/Settings/Controllers/SecurityController.php:94
-* @route '/settings/email'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:94
+ * @route '/settings/email'
+ */
 updateEmail.url = (options?: RouteQueryOptions) => {
     return updateEmail.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::updateEmail
-* @see app/Modules/Settings/Controllers/SecurityController.php:94
-* @route '/settings/email'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:94
+ * @route '/settings/email'
+ */
 updateEmail.put = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: updateEmail.url(options),
     method: 'put',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\SecurityController::updateEmail
+ * @see app/Modules/Settings/Controllers/SecurityController.php:94
+ * @route '/settings/email'
+ */
+    const updateEmailForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: updateEmail.url({
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\SecurityController::updateEmail
+ * @see app/Modules/Settings/Controllers/SecurityController.php:94
+ * @route '/settings/email'
+ */
+        updateEmailForm.put = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: updateEmail.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    updateEmail.form = updateEmailForm
 const SecurityController = { edit, update, updateEmail }
 
 export default SecurityController

--- a/resources/js/actions/App/Modules/index.ts
+++ b/resources/js/actions/App/Modules/index.ts
@@ -6,16 +6,15 @@ import Wims from './Wims'
 import Fast from './Fast'
 import Trace from './Trace'
 import Settings from './Settings'
-
 const Modules = {
     WorkOs: Object.assign(WorkOs, WorkOs),
-    Portal: Object.assign(Portal, Portal),
-    Coreportal: Object.assign(Coreportal, Coreportal),
-    Pagi: Object.assign(Pagi, Pagi),
-    Wims: Object.assign(Wims, Wims),
-    Fast: Object.assign(Fast, Fast),
-    Trace: Object.assign(Trace, Trace),
-    Settings: Object.assign(Settings, Settings),
+Portal: Object.assign(Portal, Portal),
+Coreportal: Object.assign(Coreportal, Coreportal),
+Pagi: Object.assign(Pagi, Pagi),
+Wims: Object.assign(Wims, Wims),
+Fast: Object.assign(Fast, Fast),
+Trace: Object.assign(Trace, Trace),
+Settings: Object.assign(Settings, Settings),
 }
 
 export default Modules

--- a/resources/js/actions/App/index.ts
+++ b/resources/js/actions/App/index.ts
@@ -1,9 +1,8 @@
 import Modules from './Modules'
 import Http from './Http'
-
 const App = {
     Modules: Object.assign(Modules, Modules),
-    Http: Object.assign(Http, Http),
+Http: Object.assign(Http, Http),
 }
 
 export default App

--- a/resources/js/actions/Illuminate/Routing/RedirectController.ts
+++ b/resources/js/actions/Illuminate/Routing/RedirectController.ts
@@ -1,9 +1,197 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../wayfinder'
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/fast/user'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+const RedirectController949c0c6332838fbe1a40781cbb14fb48 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+    method: 'get',
+})
+
+RedirectController949c0c6332838fbe1a40781cbb14fb48.definition = {
+    methods: ["get","head","post","put","patch","delete","options"],
+    url: '/wims/admin/template-laporan-akhir',
+} satisfies RouteDefinition<["get","head","post","put","patch","delete","options"]>
+
+/**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+RedirectController949c0c6332838fbe1a40781cbb14fb48.url = (options?: RouteQueryOptions) => {
+    return RedirectController949c0c6332838fbe1a40781cbb14fb48.definition.url + queryParams(options)
+}
+
+/**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+RedirectController949c0c6332838fbe1a40781cbb14fb48.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
+    url: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+    method: 'get',
+})
+/**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+RedirectController949c0c6332838fbe1a40781cbb14fb48.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
+    url: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+    method: 'head',
+})
+/**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+RedirectController949c0c6332838fbe1a40781cbb14fb48.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
+    url: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+    method: 'post',
+})
+/**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+RedirectController949c0c6332838fbe1a40781cbb14fb48.put = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
+    url: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+    method: 'put',
+})
+/**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+RedirectController949c0c6332838fbe1a40781cbb14fb48.patch = (options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
+    url: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+    method: 'patch',
+})
+/**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+RedirectController949c0c6332838fbe1a40781cbb14fb48.delete = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
+    url: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+    method: 'delete',
+})
+/**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+RedirectController949c0c6332838fbe1a40781cbb14fb48.options = (options?: RouteQueryOptions): RouteDefinition<'options'> => ({
+    url: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+    method: 'options',
+})
+
+    /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+    const RedirectController949c0c6332838fbe1a40781cbb14fb48Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+        RedirectController949c0c6332838fbe1a40781cbb14fb48Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+        RedirectController949c0c6332838fbe1a40781cbb14fb48Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController949c0c6332838fbe1a40781cbb14fb48.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+        RedirectController949c0c6332838fbe1a40781cbb14fb48Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController949c0c6332838fbe1a40781cbb14fb48.url(options),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+        RedirectController949c0c6332838fbe1a40781cbb14fb48Form.put = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController949c0c6332838fbe1a40781cbb14fb48.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+        RedirectController949c0c6332838fbe1a40781cbb14fb48Form.patch = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController949c0c6332838fbe1a40781cbb14fb48.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+        RedirectController949c0c6332838fbe1a40781cbb14fb48Form.delete = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController949c0c6332838fbe1a40781cbb14fb48.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/wims/admin/template-laporan-akhir'
+ */
+        RedirectController949c0c6332838fbe1a40781cbb14fb48Form.options = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController949c0c6332838fbe1a40781cbb14fb48.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'OPTIONS',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    RedirectController949c0c6332838fbe1a40781cbb14fb48.form = RedirectController949c0c6332838fbe1a40781cbb14fb48Form
+    /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
 const RedirectControllerb956d0d91254eb85cf9d7286f73c60a8 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
     method: 'get',
@@ -16,88 +204,182 @@ RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.definition = {
 
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/fast/user'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
 RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url = (options?: RouteQueryOptions) => {
     return RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.definition.url + queryParams(options)
 }
 
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/fast/user'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
 RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
     method: 'get',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/fast/user'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
 RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
     method: 'head',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/fast/user'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
 RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
     method: 'post',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/fast/user'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
 RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.put = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
     method: 'put',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/fast/user'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
 RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.patch = (options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
     method: 'patch',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/fast/user'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
 RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.delete = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
     method: 'delete',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/fast/user'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
 RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.options = (options?: RouteQueryOptions): RouteDefinition<'options'> => ({
     url: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
     method: 'options',
 })
 
-/**
+    /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/mahasiswa'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
+    const RedirectControllerb956d0d91254eb85cf9d7286f73c60a8Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
+        RedirectControllerb956d0d91254eb85cf9d7286f73c60a8Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
+        RedirectControllerb956d0d91254eb85cf9d7286f73c60a8Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
+        RedirectControllerb956d0d91254eb85cf9d7286f73c60a8Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url(options),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
+        RedirectControllerb956d0d91254eb85cf9d7286f73c60a8Form.put = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
+        RedirectControllerb956d0d91254eb85cf9d7286f73c60a8Form.patch = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
+        RedirectControllerb956d0d91254eb85cf9d7286f73c60a8Form.delete = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/fast/user'
+ */
+        RedirectControllerb956d0d91254eb85cf9d7286f73c60a8Form.options = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'OPTIONS',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    RedirectControllerb956d0d91254eb85cf9d7286f73c60a8.form = RedirectControllerb956d0d91254eb85cf9d7286f73c60a8Form
+    /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
 const RedirectController759e2bde4df66f6a3efb8b549fb8a506 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
     method: 'get',
@@ -110,88 +392,182 @@ RedirectController759e2bde4df66f6a3efb8b549fb8a506.definition = {
 
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/mahasiswa'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
 RedirectController759e2bde4df66f6a3efb8b549fb8a506.url = (options?: RouteQueryOptions) => {
     return RedirectController759e2bde4df66f6a3efb8b549fb8a506.definition.url + queryParams(options)
 }
 
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/mahasiswa'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
 RedirectController759e2bde4df66f6a3efb8b549fb8a506.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
     method: 'get',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/mahasiswa'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
 RedirectController759e2bde4df66f6a3efb8b549fb8a506.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
     method: 'head',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/mahasiswa'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
 RedirectController759e2bde4df66f6a3efb8b549fb8a506.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
     method: 'post',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/mahasiswa'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
 RedirectController759e2bde4df66f6a3efb8b549fb8a506.put = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
     method: 'put',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/mahasiswa'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
 RedirectController759e2bde4df66f6a3efb8b549fb8a506.patch = (options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
     method: 'patch',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/mahasiswa'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
 RedirectController759e2bde4df66f6a3efb8b549fb8a506.delete = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
     method: 'delete',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/mahasiswa'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
 RedirectController759e2bde4df66f6a3efb8b549fb8a506.options = (options?: RouteQueryOptions): RouteDefinition<'options'> => ({
     url: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
     method: 'options',
 })
 
-/**
+    /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/dosen'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
+    const RedirectController759e2bde4df66f6a3efb8b549fb8a506Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
+        RedirectController759e2bde4df66f6a3efb8b549fb8a506Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
+        RedirectController759e2bde4df66f6a3efb8b549fb8a506Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
+        RedirectController759e2bde4df66f6a3efb8b549fb8a506Form.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url(options),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
+        RedirectController759e2bde4df66f6a3efb8b549fb8a506Form.put = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
+        RedirectController759e2bde4df66f6a3efb8b549fb8a506Form.patch = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
+        RedirectController759e2bde4df66f6a3efb8b549fb8a506Form.delete = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/mahasiswa'
+ */
+        RedirectController759e2bde4df66f6a3efb8b549fb8a506Form.options = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController759e2bde4df66f6a3efb8b549fb8a506.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'OPTIONS',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    RedirectController759e2bde4df66f6a3efb8b549fb8a506.form = RedirectController759e2bde4df66f6a3efb8b549fb8a506Form
+    /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
 const RedirectController54d112b503ad73394d249fc6ec29142c = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
     method: 'get',
@@ -204,88 +580,182 @@ RedirectController54d112b503ad73394d249fc6ec29142c.definition = {
 
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/dosen'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
 RedirectController54d112b503ad73394d249fc6ec29142c.url = (options?: RouteQueryOptions) => {
     return RedirectController54d112b503ad73394d249fc6ec29142c.definition.url + queryParams(options)
 }
 
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/dosen'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
 RedirectController54d112b503ad73394d249fc6ec29142c.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
     method: 'get',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/dosen'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
 RedirectController54d112b503ad73394d249fc6ec29142c.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
     method: 'head',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/dosen'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
 RedirectController54d112b503ad73394d249fc6ec29142c.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
     method: 'post',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/dosen'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
 RedirectController54d112b503ad73394d249fc6ec29142c.put = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
     method: 'put',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/dosen'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
 RedirectController54d112b503ad73394d249fc6ec29142c.patch = (options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
     method: 'patch',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/dosen'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
 RedirectController54d112b503ad73394d249fc6ec29142c.delete = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
     method: 'delete',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/dosen'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
 RedirectController54d112b503ad73394d249fc6ec29142c.options = (options?: RouteQueryOptions): RouteDefinition<'options'> => ({
     url: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
     method: 'options',
 })
 
-/**
+    /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/settings'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
+    const RedirectController54d112b503ad73394d249fc6ec29142cForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
+        RedirectController54d112b503ad73394d249fc6ec29142cForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
+        RedirectController54d112b503ad73394d249fc6ec29142cForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController54d112b503ad73394d249fc6ec29142c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
+        RedirectController54d112b503ad73394d249fc6ec29142cForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController54d112b503ad73394d249fc6ec29142c.url(options),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
+        RedirectController54d112b503ad73394d249fc6ec29142cForm.put = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController54d112b503ad73394d249fc6ec29142c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
+        RedirectController54d112b503ad73394d249fc6ec29142cForm.patch = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController54d112b503ad73394d249fc6ec29142c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
+        RedirectController54d112b503ad73394d249fc6ec29142cForm.delete = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController54d112b503ad73394d249fc6ec29142c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/dosen'
+ */
+        RedirectController54d112b503ad73394d249fc6ec29142cForm.options = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController54d112b503ad73394d249fc6ec29142c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'OPTIONS',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    RedirectController54d112b503ad73394d249fc6ec29142c.form = RedirectController54d112b503ad73394d249fc6ec29142cForm
+    /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
 const RedirectController4b87d2df7e3aa853f6720faea796e36c = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
     method: 'get',
@@ -298,82 +768,177 @@ RedirectController4b87d2df7e3aa853f6720faea796e36c.definition = {
 
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/settings'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
 RedirectController4b87d2df7e3aa853f6720faea796e36c.url = (options?: RouteQueryOptions) => {
     return RedirectController4b87d2df7e3aa853f6720faea796e36c.definition.url + queryParams(options)
 }
 
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/settings'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
 RedirectController4b87d2df7e3aa853f6720faea796e36c.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
     method: 'get',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/settings'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
 RedirectController4b87d2df7e3aa853f6720faea796e36c.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
     method: 'head',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/settings'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
 RedirectController4b87d2df7e3aa853f6720faea796e36c.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
     method: 'post',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/settings'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
 RedirectController4b87d2df7e3aa853f6720faea796e36c.put = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
     method: 'put',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/settings'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
 RedirectController4b87d2df7e3aa853f6720faea796e36c.patch = (options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
     method: 'patch',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/settings'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
 RedirectController4b87d2df7e3aa853f6720faea796e36c.delete = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
     method: 'delete',
 })
-
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
-* @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
-* @route '/settings'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
 RedirectController4b87d2df7e3aa853f6720faea796e36c.options = (options?: RouteQueryOptions): RouteDefinition<'options'> => ({
     url: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
     method: 'options',
 })
+
+    /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
+    const RedirectController4b87d2df7e3aa853f6720faea796e36cForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
+        RedirectController4b87d2df7e3aa853f6720faea796e36cForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
+        RedirectController4b87d2df7e3aa853f6720faea796e36cForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController4b87d2df7e3aa853f6720faea796e36c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
+        RedirectController4b87d2df7e3aa853f6720faea796e36cForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController4b87d2df7e3aa853f6720faea796e36c.url(options),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
+        RedirectController4b87d2df7e3aa853f6720faea796e36cForm.put = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController4b87d2df7e3aa853f6720faea796e36c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
+        RedirectController4b87d2df7e3aa853f6720faea796e36cForm.patch = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController4b87d2df7e3aa853f6720faea796e36c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
+        RedirectController4b87d2df7e3aa853f6720faea796e36cForm.delete = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: RedirectController4b87d2df7e3aa853f6720faea796e36c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+            /**
+* @see \Illuminate\Routing\RedirectController::__invoke
+ * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19
+ * @route '/settings'
+ */
+        RedirectController4b87d2df7e3aa853f6720faea796e36cForm.options = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: RedirectController4b87d2df7e3aa853f6720faea796e36c.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'OPTIONS',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    RedirectController4b87d2df7e3aa853f6720faea796e36c.form = RedirectController4b87d2df7e3aa853f6720faea796e36cForm
 
 /**
 * Multiple routes resolve to \Illuminate\Routing\RedirectController::RedirectController, so this export is a
@@ -381,6 +946,7 @@ RedirectController4b87d2df7e3aa853f6720faea796e36c.options = (options?: RouteQue
 * or import the route by name from your generated `routes/` directory.
 */
 const RedirectController = {
+    '/wims/admin/template-laporan-akhir': RedirectController949c0c6332838fbe1a40781cbb14fb48,
     '/fast/user': RedirectControllerb956d0d91254eb85cf9d7286f73c60a8,
     '/mahasiswa': RedirectController759e2bde4df66f6a3efb8b549fb8a506,
     '/dosen': RedirectController54d112b503ad73394d249fc6ec29142c,

--- a/resources/js/actions/Illuminate/Routing/index.ts
+++ b/resources/js/actions/Illuminate/Routing/index.ts
@@ -1,5 +1,4 @@
 import RedirectController from './RedirectController'
-
 const Routing = {
     RedirectController: Object.assign(RedirectController, RedirectController),
 }

--- a/resources/js/actions/Illuminate/index.ts
+++ b/resources/js/actions/Illuminate/index.ts
@@ -1,9 +1,8 @@
 import Routing from './Routing'
 import Broadcasting from './Broadcasting'
-
 const Illuminate = {
     Routing: Object.assign(Routing, Routing),
-    Broadcasting: Object.assign(Broadcasting, Broadcasting),
+Broadcasting: Object.assign(Broadcasting, Broadcasting),
 }
 
 export default Illuminate

--- a/resources/js/actions/Inertia/Controller.ts
+++ b/resources/js/actions/Inertia/Controller.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/portal'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
 const Controllerbbbc08286ef6a2400dbe9df4f48889ac = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: Controllerbbbc08286ef6a2400dbe9df4f48889ac.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ Controllerbbbc08286ef6a2400dbe9df4f48889ac.definition = {
 
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/portal'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
 Controllerbbbc08286ef6a2400dbe9df4f48889ac.url = (options?: RouteQueryOptions) => {
     return Controllerbbbc08286ef6a2400dbe9df4f48889ac.definition.url + queryParams(options)
 }
 
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/portal'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
 Controllerbbbc08286ef6a2400dbe9df4f48889ac.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: Controllerbbbc08286ef6a2400dbe9df4f48889ac.url(options),
     method: 'get',
 })
-
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/portal'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
 Controllerbbbc08286ef6a2400dbe9df4f48889ac.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: Controllerbbbc08286ef6a2400dbe9df4f48889ac.url(options),
     method: 'head',
 })
 
-/**
+    /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/settings/appearance'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
+    const Controllerbbbc08286ef6a2400dbe9df4f48889acForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: Controllerbbbc08286ef6a2400dbe9df4f48889ac.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
+        Controllerbbbc08286ef6a2400dbe9df4f48889acForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: Controllerbbbc08286ef6a2400dbe9df4f48889ac.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
+        Controllerbbbc08286ef6a2400dbe9df4f48889acForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: Controllerbbbc08286ef6a2400dbe9df4f48889ac.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    Controllerbbbc08286ef6a2400dbe9df4f48889ac.form = Controllerbbbc08286ef6a2400dbe9df4f48889acForm
+    /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
 const Controllere19ee86e9cf603ce1a59a1ec5d21dec5 = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: Controllere19ee86e9cf603ce1a59a1ec5d21dec5.url(options),
     method: 'get',
@@ -60,32 +94,67 @@ Controllere19ee86e9cf603ce1a59a1ec5d21dec5.definition = {
 
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/settings/appearance'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
 Controllere19ee86e9cf603ce1a59a1ec5d21dec5.url = (options?: RouteQueryOptions) => {
     return Controllere19ee86e9cf603ce1a59a1ec5d21dec5.definition.url + queryParams(options)
 }
 
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/settings/appearance'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
 Controllere19ee86e9cf603ce1a59a1ec5d21dec5.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: Controllere19ee86e9cf603ce1a59a1ec5d21dec5.url(options),
     method: 'get',
 })
-
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/settings/appearance'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
 Controllere19ee86e9cf603ce1a59a1ec5d21dec5.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: Controllere19ee86e9cf603ce1a59a1ec5d21dec5.url(options),
     method: 'head',
 })
+
+    /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
+    const Controllere19ee86e9cf603ce1a59a1ec5d21dec5Form = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: Controllere19ee86e9cf603ce1a59a1ec5d21dec5.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
+        Controllere19ee86e9cf603ce1a59a1ec5d21dec5Form.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: Controllere19ee86e9cf603ce1a59a1ec5d21dec5.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
+        Controllere19ee86e9cf603ce1a59a1ec5d21dec5Form.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: Controllere19ee86e9cf603ce1a59a1ec5d21dec5.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    Controllere19ee86e9cf603ce1a59a1ec5d21dec5.form = Controllere19ee86e9cf603ce1a59a1ec5d21dec5Form
 
 /**
 * Multiple routes resolve to \Inertia\Controller::Controller, so this export is a

--- a/resources/js/actions/Inertia/index.ts
+++ b/resources/js/actions/Inertia/index.ts
@@ -1,5 +1,4 @@
 import Controller from './Controller'
-
 const Inertia = {
     Controller: Object.assign(Controller, Controller),
 }

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/AuthenticatedSessionController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/AuthenticatedSessionController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
-* @route '/login'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
 export const create = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ create.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
-* @route '/login'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
 create.url = (options?: RouteQueryOptions) => {
     return create.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
-* @route '/login'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
 create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
-* @route '/login'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
 create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: create.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
+    const createForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: create.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
+        createForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
+        createForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    create.form = createForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::destroy
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
-* @route '/logout'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
 export const destroy = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: destroy.url(options),
     method: 'post',
@@ -60,23 +94,44 @@ destroy.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::destroy
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
-* @route '/logout'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
 destroy.url = (options?: RouteQueryOptions) => {
     return destroy.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::destroy
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
-* @route '/logout'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
 destroy.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: destroy.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::destroy
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
+    const destroyForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroy.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::destroy
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
+        destroyForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroy.url(options),
+            method: 'post',
+        })
+    
+    destroy.form = destroyForm
 const AuthenticatedSessionController = { create, destroy }
 
 export default AuthenticatedSessionController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/ConfirmablePasswordController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/ConfirmablePasswordController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
 export const show = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ show.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
 show.url = (options?: RouteQueryOptions) => {
     return show.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
 show.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
 show.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
+    const showForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
+        showForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
+        showForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -60,23 +94,44 @@ store.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const ConfirmablePasswordController = { show, store }
 
 export default ConfirmablePasswordController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/ConfirmedPasswordStatusController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/ConfirmedPasswordStatusController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
-* @route '/user/confirmed-password-status'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
 export const show = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(options),
     method: 'get',
@@ -16,33 +16,67 @@ show.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
-* @route '/user/confirmed-password-status'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
 show.url = (options?: RouteQueryOptions) => {
     return show.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
-* @route '/user/confirmed-password-status'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
 show.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
-* @route '/user/confirmed-password-status'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
 show.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
+    const showForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
+        showForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
+        showForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 const ConfirmedPasswordStatusController = { show }
 
 export default ConfirmedPasswordStatusController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/ConfirmedTwoFactorAuthenticationController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/ConfirmedTwoFactorAuthenticationController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
-* @route '/user/confirmed-two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -16,23 +16,44 @@ store.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
-* @route '/user/confirmed-two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
-* @route '/user/confirmed-two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const ConfirmedTwoFactorAuthenticationController = { store }
 
 export default ConfirmedTwoFactorAuthenticationController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/NewPasswordController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/NewPasswordController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
-* @route '/reset-password/{token}'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
 export const create = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(args, options),
     method: 'get',
@@ -16,25 +16,26 @@ create.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
-* @route '/reset-password/{token}'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
 create.url = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { token: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            token: args[0],
-        }
+                    token: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        token: args.token,
-    }
+                        token: args.token,
+                }
 
     return create.definition.url
             .replace('{token}', parsedArgs.token.toString())
@@ -43,29 +44,63 @@ create.url = (args: { token: string | number } | [token: string | number ] | str
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
-* @route '/reset-password/{token}'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
 create.get = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
-* @route '/reset-password/{token}'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
 create.head = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: create.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
+    const createForm = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: create.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
+        createForm.get = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
+        createForm.head = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    create.form = createForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
-* @route '/reset-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -78,23 +113,44 @@ store.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
-* @route '/reset-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
-* @route '/reset-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const NewPasswordController = { create, store }
 
 export default NewPasswordController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/PasswordResetLinkController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/PasswordResetLinkController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
 export const create = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ create.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
 create.url = (options?: RouteQueryOptions) => {
     return create.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
 create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
 create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: create.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
+    const createForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: create.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
+        createForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
+        createForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    create.form = createForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -60,23 +94,44 @@ store.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const PasswordResetLinkController = { create, store }
 
 export default PasswordResetLinkController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/RecoveryCodeController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/RecoveryCodeController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::index
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
 export const index = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ index.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::index
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
 index.url = (options?: RouteQueryOptions) => {
     return index.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::index
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
 index.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: index.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::index
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
 index.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: index.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::index
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
+    const indexForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: index.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::index
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
+        indexForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::index
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
+        indexForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: index.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    index.form = indexForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -60,23 +94,44 @@ store.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const RecoveryCodeController = { index, store }
 
 export default RecoveryCodeController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/RegisteredUserController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/RegisteredUserController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
 export const create = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ create.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
 create.url = (options?: RouteQueryOptions) => {
     return create.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
 create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
 create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: create.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
+    const createForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: create.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
+        createForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
+        createForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    create.form = createForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -60,23 +94,44 @@ store.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const RegisteredUserController = { create, store }
 
 export default RegisteredUserController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/TwoFactorAuthenticatedSessionController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/TwoFactorAuthenticatedSessionController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
-* @route '/two-factor-challenge'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
 export const create = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
@@ -16,33 +16,67 @@ create.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
-* @route '/two-factor-challenge'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
 create.url = (options?: RouteQueryOptions) => {
     return create.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
-* @route '/two-factor-challenge'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
 create.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: create.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::create
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
-* @route '/two-factor-challenge'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
 create.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: create.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
+    const createForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: create.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
+        createForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::create
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
+        createForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: create.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    create.form = createForm
 const TwoFactorAuthenticatedSessionController = { create }
 
 export default TwoFactorAuthenticatedSessionController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/TwoFactorAuthenticationController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/TwoFactorAuthenticationController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -16,28 +16,49 @@ store.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::destroy
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
 export const destroy = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: destroy.url(options),
     method: 'delete',
@@ -50,23 +71,54 @@ destroy.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::destroy
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
 destroy.url = (options?: RouteQueryOptions) => {
     return destroy.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::destroy
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
 destroy.delete = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: destroy.url(options),
     method: 'delete',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::destroy
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
+    const destroyForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroy.url({
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::destroy
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
+        destroyForm.delete = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroy.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroy.form = destroyForm
 const TwoFactorAuthenticationController = { store, destroy }
 
 export default TwoFactorAuthenticationController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/TwoFactorQrCodeController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/TwoFactorQrCodeController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
-* @route '/user/two-factor-qr-code'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
 export const show = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(options),
     method: 'get',
@@ -16,33 +16,67 @@ show.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
-* @route '/user/two-factor-qr-code'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
 show.url = (options?: RouteQueryOptions) => {
     return show.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
-* @route '/user/two-factor-qr-code'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
 show.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
-* @route '/user/two-factor-qr-code'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
 show.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
+    const showForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
+        showForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
+        showForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 const TwoFactorQrCodeController = { show }
 
 export default TwoFactorQrCodeController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/TwoFactorSecretKeyController.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/TwoFactorSecretKeyController.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
-* @route '/user/two-factor-secret-key'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
 export const show = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(options),
     method: 'get',
@@ -16,33 +16,67 @@ show.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
-* @route '/user/two-factor-secret-key'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
 show.url = (options?: RouteQueryOptions) => {
     return show.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
-* @route '/user/two-factor-secret-key'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
 show.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: show.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::show
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
-* @route '/user/two-factor-secret-key'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
 show.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: show.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
+    const showForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: show.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
+        showForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::show
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
+        showForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: show.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    show.form = showForm
 const TwoFactorSecretKeyController = { show }
 
 export default TwoFactorSecretKeyController

--- a/resources/js/actions/Laravel/Fortify/Http/Controllers/index.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/Controllers/index.ts
@@ -13,23 +13,22 @@ import ConfirmedTwoFactorAuthenticationController from './ConfirmedTwoFactorAuth
 import TwoFactorQrCodeController from './TwoFactorQrCodeController'
 import TwoFactorSecretKeyController from './TwoFactorSecretKeyController'
 import RecoveryCodeController from './RecoveryCodeController'
-
 const Controllers = {
     AuthenticatedSessionController: Object.assign(AuthenticatedSessionController, AuthenticatedSessionController),
-    PasswordResetLinkController: Object.assign(PasswordResetLinkController, PasswordResetLinkController),
-    NewPasswordController: Object.assign(NewPasswordController, NewPasswordController),
-    RegisteredUserController: Object.assign(RegisteredUserController, RegisteredUserController),
-    EmailVerificationPromptController: Object.assign(EmailVerificationPromptController, EmailVerificationPromptController),
-    VerifyEmailController: Object.assign(VerifyEmailController, VerifyEmailController),
-    EmailVerificationNotificationController: Object.assign(EmailVerificationNotificationController, EmailVerificationNotificationController),
-    ConfirmablePasswordController: Object.assign(ConfirmablePasswordController, ConfirmablePasswordController),
-    ConfirmedPasswordStatusController: Object.assign(ConfirmedPasswordStatusController, ConfirmedPasswordStatusController),
-    TwoFactorAuthenticatedSessionController: Object.assign(TwoFactorAuthenticatedSessionController, TwoFactorAuthenticatedSessionController),
-    TwoFactorAuthenticationController: Object.assign(TwoFactorAuthenticationController, TwoFactorAuthenticationController),
-    ConfirmedTwoFactorAuthenticationController: Object.assign(ConfirmedTwoFactorAuthenticationController, ConfirmedTwoFactorAuthenticationController),
-    TwoFactorQrCodeController: Object.assign(TwoFactorQrCodeController, TwoFactorQrCodeController),
-    TwoFactorSecretKeyController: Object.assign(TwoFactorSecretKeyController, TwoFactorSecretKeyController),
-    RecoveryCodeController: Object.assign(RecoveryCodeController, RecoveryCodeController),
+PasswordResetLinkController: Object.assign(PasswordResetLinkController, PasswordResetLinkController),
+NewPasswordController: Object.assign(NewPasswordController, NewPasswordController),
+RegisteredUserController: Object.assign(RegisteredUserController, RegisteredUserController),
+EmailVerificationPromptController: Object.assign(EmailVerificationPromptController, EmailVerificationPromptController),
+VerifyEmailController: Object.assign(VerifyEmailController, VerifyEmailController),
+EmailVerificationNotificationController: Object.assign(EmailVerificationNotificationController, EmailVerificationNotificationController),
+ConfirmablePasswordController: Object.assign(ConfirmablePasswordController, ConfirmablePasswordController),
+ConfirmedPasswordStatusController: Object.assign(ConfirmedPasswordStatusController, ConfirmedPasswordStatusController),
+TwoFactorAuthenticatedSessionController: Object.assign(TwoFactorAuthenticatedSessionController, TwoFactorAuthenticatedSessionController),
+TwoFactorAuthenticationController: Object.assign(TwoFactorAuthenticationController, TwoFactorAuthenticationController),
+ConfirmedTwoFactorAuthenticationController: Object.assign(ConfirmedTwoFactorAuthenticationController, ConfirmedTwoFactorAuthenticationController),
+TwoFactorQrCodeController: Object.assign(TwoFactorQrCodeController, TwoFactorQrCodeController),
+TwoFactorSecretKeyController: Object.assign(TwoFactorSecretKeyController, TwoFactorSecretKeyController),
+RecoveryCodeController: Object.assign(RecoveryCodeController, RecoveryCodeController),
 }
 
 export default Controllers

--- a/resources/js/actions/Laravel/Fortify/Http/index.ts
+++ b/resources/js/actions/Laravel/Fortify/Http/index.ts
@@ -1,5 +1,4 @@
 import Controllers from './Controllers'
-
 const Http = {
     Controllers: Object.assign(Controllers, Controllers),
 }

--- a/resources/js/actions/Laravel/Fortify/index.ts
+++ b/resources/js/actions/Laravel/Fortify/index.ts
@@ -1,5 +1,4 @@
 import Http from './Http'
-
 const Fortify = {
     Http: Object.assign(Http, Http),
 }

--- a/resources/js/actions/Laravel/index.ts
+++ b/resources/js/actions/Laravel/index.ts
@@ -2,12 +2,11 @@ import Fortify from './Fortify'
 import Horizon from './Horizon'
 import Sanctum from './Sanctum'
 import Telescope from './Telescope'
-
 const Laravel = {
     Fortify: Object.assign(Fortify, Fortify),
-    Horizon: Object.assign(Horizon, Horizon),
-    Sanctum: Object.assign(Sanctum, Sanctum),
-    Telescope: Object.assign(Telescope, Telescope),
+Horizon: Object.assign(Horizon, Horizon),
+Sanctum: Object.assign(Sanctum, Sanctum),
+Telescope: Object.assign(Telescope, Telescope),
 }
 
 export default Laravel

--- a/resources/js/pages/Modules/Fast/Mahasiswa/Dashboard.vue
+++ b/resources/js/pages/Modules/Fast/Mahasiswa/Dashboard.vue
@@ -506,6 +506,17 @@ function openViewer(item: LatestSubmission, mode: 'preview' | 'pdf') {
     viewerOpen.value = true;
 }
 
+function downloadPdf(item: LatestSubmission) {
+    const url = `/documents/surat/${item.id}/pdf`;
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${item.jenisSurat} - ${item.reference}.pdf`;
+    link.rel = 'noopener';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+}
+
 function closeViewer() {
     viewerOpen.value = false;
     setTimeout(() => {
@@ -1188,7 +1199,7 @@ function fieldError(name: string): string | undefined {
                                         type="button"
                                         title="Download PDF"
                                         class="fast-btn fast-btn-primary px-3 py-1.5 text-[10px] font-medium"
-                                        @click="openViewer(item, 'pdf')"
+                                        @click="downloadPdf(item)"
                                     >
                                         <Download class="size-3" /> PDF
                                     </button>

--- a/resources/js/pages/mahasiswa/Ajukan.vue
+++ b/resources/js/pages/mahasiswa/Ajukan.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import Page from "@/pages/Modules/Fast/Mahasiswa/Ajukan.vue";
+
+defineOptions({ inheritAttrs: false });
+</script>
+
+<template>
+    <Page v-bind="$attrs" />
+</template>

--- a/resources/js/routes/appearance/index.ts
+++ b/resources/js/routes/appearance/index.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/settings/appearance'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
 export const edit = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(options),
     method: 'get',
@@ -16,33 +16,67 @@ edit.definition = {
 
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/settings/appearance'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
 edit.url = (options?: RouteQueryOptions) => {
     return edit.definition.url + queryParams(options)
 }
 
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/settings/appearance'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
 edit.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(options),
     method: 'get',
 })
-
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/settings/appearance'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
 edit.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: edit.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
+    const editForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: edit.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
+        editForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/settings/appearance'
+ */
+        editForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    edit.form = editForm
 const appearance = {
     edit: Object.assign(edit, edit),
 }

--- a/resources/js/routes/index.ts
+++ b/resources/js/routes/index.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults, validateParameters } from './../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults, validateParameters } from './../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::login
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
-* @route '/login'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
 export const login = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: login.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ login.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::login
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
-* @route '/login'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
 login.url = (options?: RouteQueryOptions) => {
     return login.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::login
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
-* @route '/login'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
 login.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: login.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::login
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
-* @route '/login'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
 login.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: login.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::login
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
+    const loginForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: login.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::login
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
+        loginForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: login.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::login
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:47
+ * @route '/login'
+ */
+        loginForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: login.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    login.form = loginForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::logout
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
-* @route '/logout'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
 export const logout = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: logout.url(options),
     method: 'post',
@@ -60,28 +94,49 @@ logout.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::logout
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
-* @route '/logout'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
 logout.url = (options?: RouteQueryOptions) => {
     return logout.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::logout
-* @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
-* @route '/logout'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
 logout.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: logout.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::logout
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
+    const logoutForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: logout.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\AuthenticatedSessionController::logout
+ * @see vendor/laravel/fortify/src/Http/Controllers/AuthenticatedSessionController.php:100
+ * @route '/logout'
+ */
+        logoutForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: logout.url(options),
+            method: 'post',
+        })
+    
+    logout.form = logoutForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::register
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
 export const register = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: register.url(options),
     method: 'get',
@@ -94,37 +149,71 @@ register.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::register
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
 register.url = (options?: RouteQueryOptions) => {
     return register.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::register
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
 register.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: register.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::register
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
 register.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: register.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::register
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
+    const registerForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: register.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::register
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
+        registerForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: register.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::register
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:41
+ * @route '/register'
+ */
+        registerForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: register.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    register.form = registerForm
 /**
-* @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
-* @route '/secure-pulse-9a2c'
-*/
+ * @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
+ * @route '/pulse'
+ */
 export const pulse = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: pulse.url(options),
     method: 'get',
@@ -132,40 +221,71 @@ export const pulse = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
 
 pulse.definition = {
     methods: ["get","head"],
-    url: '/secure-pulse-9a2c',
+    url: '/pulse',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
-* @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
-* @route '/secure-pulse-9a2c'
-*/
+ * @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
+ * @route '/pulse'
+ */
 pulse.url = (options?: RouteQueryOptions) => {
     return pulse.definition.url + queryParams(options)
 }
 
 /**
-* @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
-* @route '/secure-pulse-9a2c'
-*/
+ * @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
+ * @route '/pulse'
+ */
 pulse.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: pulse.url(options),
     method: 'get',
 })
-
 /**
-* @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
-* @route '/secure-pulse-9a2c'
-*/
+ * @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
+ * @route '/pulse'
+ */
 pulse.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: pulse.url(options),
     method: 'head',
 })
 
+    /**
+ * @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
+ * @route '/pulse'
+ */
+    const pulseForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: pulse.url(options),
+        method: 'get',
+    })
+
+            /**
+ * @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
+ * @route '/pulse'
+ */
+        pulseForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: pulse.url(options),
+            method: 'get',
+        })
+            /**
+ * @see vendor/laravel/pulse/src/PulseServiceProvider.php:116
+ * @route '/pulse'
+ */
+        pulseForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: pulse.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    pulse.form = pulseForm
 /**
 * @see \Laravel\Telescope\Http\Controllers\HomeController::telescope
-* @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
-* @route '/secure-telescope-8f3b/{view?}'
-*/
+ * @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
+ * @route '/telescope/{view?}'
+ */
 export const telescope = (args?: { view?: string | number } | [view: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: telescope.url(args, options),
     method: 'get',
@@ -173,34 +293,35 @@ export const telescope = (args?: { view?: string | number } | [view: string | nu
 
 telescope.definition = {
     methods: ["get","head"],
-    url: '/secure-telescope-8f3b/{view?}',
+    url: '/telescope/{view?}',
 } satisfies RouteDefinition<["get","head"]>
 
 /**
 * @see \Laravel\Telescope\Http\Controllers\HomeController::telescope
-* @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
-* @route '/secure-telescope-8f3b/{view?}'
-*/
+ * @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
+ * @route '/telescope/{view?}'
+ */
 telescope.url = (args?: { view?: string | number } | [view: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { view: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            view: args[0],
-        }
+                    view: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     validateParameters(args, [
-        "view",
-    ])
+            "view",
+        ])
 
     const parsedArgs = {
-        view: args?.view,
-    }
+                        view: args?.view,
+                }
 
     return telescope.definition.url
             .replace('{view?}', parsedArgs.view?.toString() ?? '')
@@ -209,28 +330,62 @@ telescope.url = (args?: { view?: string | number } | [view: string | number ] | 
 
 /**
 * @see \Laravel\Telescope\Http\Controllers\HomeController::telescope
-* @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
-* @route '/secure-telescope-8f3b/{view?}'
-*/
+ * @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
+ * @route '/telescope/{view?}'
+ */
 telescope.get = (args?: { view?: string | number } | [view: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: telescope.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Telescope\Http\Controllers\HomeController::telescope
-* @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
-* @route '/secure-telescope-8f3b/{view?}'
-*/
+ * @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
+ * @route '/telescope/{view?}'
+ */
 telescope.head = (args?: { view?: string | number } | [view: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: telescope.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Telescope\Http\Controllers\HomeController::telescope
+ * @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
+ * @route '/telescope/{view?}'
+ */
+    const telescopeForm = (args?: { view?: string | number } | [view: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: telescope.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Telescope\Http\Controllers\HomeController::telescope
+ * @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
+ * @route '/telescope/{view?}'
+ */
+        telescopeForm.get = (args?: { view?: string | number } | [view: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: telescope.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Telescope\Http\Controllers\HomeController::telescope
+ * @see vendor/laravel/telescope/src/Http/Controllers/HomeController.php:15
+ * @route '/telescope/{view?}'
+ */
+        telescopeForm.head = (args?: { view?: string | number } | [view: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: telescope.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    telescope.form = telescopeForm
 /**
-* @see routes/web.php:56
-* @route '/'
-*/
+ * @see routes/web.php:58
+ * @route '/'
+ */
 export const home = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: home.url(options),
     method: 'get',
@@ -242,35 +397,66 @@ home.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
-* @see routes/web.php:56
-* @route '/'
-*/
+ * @see routes/web.php:58
+ * @route '/'
+ */
 home.url = (options?: RouteQueryOptions) => {
     return home.definition.url + queryParams(options)
 }
 
 /**
-* @see routes/web.php:56
-* @route '/'
-*/
+ * @see routes/web.php:58
+ * @route '/'
+ */
 home.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: home.url(options),
     method: 'get',
 })
-
 /**
-* @see routes/web.php:56
-* @route '/'
-*/
+ * @see routes/web.php:58
+ * @route '/'
+ */
 home.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: home.url(options),
     method: 'head',
 })
 
+    /**
+ * @see routes/web.php:58
+ * @route '/'
+ */
+    const homeForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: home.url(options),
+        method: 'get',
+    })
+
+            /**
+ * @see routes/web.php:58
+ * @route '/'
+ */
+        homeForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: home.url(options),
+            method: 'get',
+        })
+            /**
+ * @see routes/web.php:58
+ * @route '/'
+ */
+        homeForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: home.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    home.form = homeForm
 /**
-* @see routes/web.php:104
-* @route '/privacy-policy'
-*/
+ * @see routes/web.php:207
+ * @route '/privacy-policy'
+ */
 export const privacyPolicy = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: privacyPolicy.url(options),
     method: 'get',
@@ -282,35 +468,66 @@ privacyPolicy.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
-* @see routes/web.php:104
-* @route '/privacy-policy'
-*/
+ * @see routes/web.php:207
+ * @route '/privacy-policy'
+ */
 privacyPolicy.url = (options?: RouteQueryOptions) => {
     return privacyPolicy.definition.url + queryParams(options)
 }
 
 /**
-* @see routes/web.php:104
-* @route '/privacy-policy'
-*/
+ * @see routes/web.php:207
+ * @route '/privacy-policy'
+ */
 privacyPolicy.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: privacyPolicy.url(options),
     method: 'get',
 })
-
 /**
-* @see routes/web.php:104
-* @route '/privacy-policy'
-*/
+ * @see routes/web.php:207
+ * @route '/privacy-policy'
+ */
 privacyPolicy.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: privacyPolicy.url(options),
     method: 'head',
 })
 
+    /**
+ * @see routes/web.php:207
+ * @route '/privacy-policy'
+ */
+    const privacyPolicyForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: privacyPolicy.url(options),
+        method: 'get',
+    })
+
+            /**
+ * @see routes/web.php:207
+ * @route '/privacy-policy'
+ */
+        privacyPolicyForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: privacyPolicy.url(options),
+            method: 'get',
+        })
+            /**
+ * @see routes/web.php:207
+ * @route '/privacy-policy'
+ */
+        privacyPolicyForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: privacyPolicy.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    privacyPolicy.form = privacyPolicyForm
 /**
-* @see routes/web.php:107
-* @route '/terms-of-service'
-*/
+ * @see routes/web.php:210
+ * @route '/terms-of-service'
+ */
 export const termsService = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: termsService.url(options),
     method: 'get',
@@ -322,35 +539,66 @@ termsService.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
-* @see routes/web.php:107
-* @route '/terms-of-service'
-*/
+ * @see routes/web.php:210
+ * @route '/terms-of-service'
+ */
 termsService.url = (options?: RouteQueryOptions) => {
     return termsService.definition.url + queryParams(options)
 }
 
 /**
-* @see routes/web.php:107
-* @route '/terms-of-service'
-*/
+ * @see routes/web.php:210
+ * @route '/terms-of-service'
+ */
 termsService.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: termsService.url(options),
     method: 'get',
 })
-
 /**
-* @see routes/web.php:107
-* @route '/terms-of-service'
-*/
+ * @see routes/web.php:210
+ * @route '/terms-of-service'
+ */
 termsService.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: termsService.url(options),
     method: 'head',
 })
 
+    /**
+ * @see routes/web.php:210
+ * @route '/terms-of-service'
+ */
+    const termsServiceForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: termsService.url(options),
+        method: 'get',
+    })
+
+            /**
+ * @see routes/web.php:210
+ * @route '/terms-of-service'
+ */
+        termsServiceForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: termsService.url(options),
+            method: 'get',
+        })
+            /**
+ * @see routes/web.php:210
+ * @route '/terms-of-service'
+ */
+        termsServiceForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: termsService.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    termsService.form = termsServiceForm
 /**
-* @see routes/web.php:110
-* @route '/cookie-policy'
-*/
+ * @see routes/web.php:213
+ * @route '/cookie-policy'
+ */
 export const cookiePolicy = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: cookiePolicy.url(options),
     method: 'get',
@@ -362,36 +610,67 @@ cookiePolicy.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
-* @see routes/web.php:110
-* @route '/cookie-policy'
-*/
+ * @see routes/web.php:213
+ * @route '/cookie-policy'
+ */
 cookiePolicy.url = (options?: RouteQueryOptions) => {
     return cookiePolicy.definition.url + queryParams(options)
 }
 
 /**
-* @see routes/web.php:110
-* @route '/cookie-policy'
-*/
+ * @see routes/web.php:213
+ * @route '/cookie-policy'
+ */
 cookiePolicy.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: cookiePolicy.url(options),
     method: 'get',
 })
-
 /**
-* @see routes/web.php:110
-* @route '/cookie-policy'
-*/
+ * @see routes/web.php:213
+ * @route '/cookie-policy'
+ */
 cookiePolicy.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: cookiePolicy.url(options),
     method: 'head',
 })
 
+    /**
+ * @see routes/web.php:213
+ * @route '/cookie-policy'
+ */
+    const cookiePolicyForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: cookiePolicy.url(options),
+        method: 'get',
+    })
+
+            /**
+ * @see routes/web.php:213
+ * @route '/cookie-policy'
+ */
+        cookiePolicyForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: cookiePolicy.url(options),
+            method: 'get',
+        })
+            /**
+ * @see routes/web.php:213
+ * @route '/cookie-policy'
+ */
+        cookiePolicyForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: cookiePolicy.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    cookiePolicy.form = cookiePolicyForm
 /**
 * @see \App\Modules\Coreportal\Controllers\PortalController::dashboard
-* @see app/Modules/Coreportal/Controllers/PortalController.php:20
-* @route '/dashboard'
-*/
+ * @see app/Modules/Coreportal/Controllers/PortalController.php:20
+ * @route '/dashboard'
+ */
 export const dashboard = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: dashboard.url(options),
     method: 'get',
@@ -404,38 +683,72 @@ dashboard.definition = {
 
 /**
 * @see \App\Modules\Coreportal\Controllers\PortalController::dashboard
-* @see app/Modules/Coreportal/Controllers/PortalController.php:20
-* @route '/dashboard'
-*/
+ * @see app/Modules/Coreportal/Controllers/PortalController.php:20
+ * @route '/dashboard'
+ */
 dashboard.url = (options?: RouteQueryOptions) => {
     return dashboard.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Coreportal\Controllers\PortalController::dashboard
-* @see app/Modules/Coreportal/Controllers/PortalController.php:20
-* @route '/dashboard'
-*/
+ * @see app/Modules/Coreportal/Controllers/PortalController.php:20
+ * @route '/dashboard'
+ */
 dashboard.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: dashboard.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Coreportal\Controllers\PortalController::dashboard
-* @see app/Modules/Coreportal/Controllers/PortalController.php:20
-* @route '/dashboard'
-*/
+ * @see app/Modules/Coreportal/Controllers/PortalController.php:20
+ * @route '/dashboard'
+ */
 dashboard.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: dashboard.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Coreportal\Controllers\PortalController::dashboard
+ * @see app/Modules/Coreportal/Controllers/PortalController.php:20
+ * @route '/dashboard'
+ */
+    const dashboardForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: dashboard.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Coreportal\Controllers\PortalController::dashboard
+ * @see app/Modules/Coreportal/Controllers/PortalController.php:20
+ * @route '/dashboard'
+ */
+        dashboardForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: dashboard.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Coreportal\Controllers\PortalController::dashboard
+ * @see app/Modules/Coreportal/Controllers/PortalController.php:20
+ * @route '/dashboard'
+ */
+        dashboardForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: dashboard.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    dashboard.form = dashboardForm
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/portal'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
 export const portal = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: portal.url(options),
     method: 'get',
@@ -448,30 +761,64 @@ portal.definition = {
 
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/portal'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
 portal.url = (options?: RouteQueryOptions) => {
     return portal.definition.url + queryParams(options)
 }
 
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/portal'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
 portal.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: portal.url(options),
     method: 'get',
 })
-
 /**
 * @see \Inertia\Controller::__invoke
-* @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
-* @route '/portal'
-*/
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
 portal.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: portal.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
+    const portalForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: portal.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
+        portalForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: portal.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Inertia\Controller::__invoke
+ * @see vendor/inertiajs/inertia-laravel/src/Controller.php:13
+ * @route '/portal'
+ */
+        portalForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: portal.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    portal.form = portalForm

--- a/resources/js/routes/login/index.ts
+++ b/resources/js/routes/login/index.ts
@@ -1,8 +1,8 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
-* @see routes/web.php:141
-* @route '/login'
-*/
+ * @see routes/web.php:244
+ * @route '/login'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -14,22 +14,41 @@ store.definition = {
 } satisfies RouteDefinition<["post"]>
 
 /**
-* @see routes/web.php:141
-* @route '/login'
-*/
+ * @see routes/web.php:244
+ * @route '/login'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
-* @see routes/web.php:141
-* @route '/login'
-*/
+ * @see routes/web.php:244
+ * @route '/login'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+ * @see routes/web.php:244
+ * @route '/login'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+ * @see routes/web.php:244
+ * @route '/login'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const login = {
     store: Object.assign(store, store),
 }

--- a/resources/js/routes/password/confirm/index.ts
+++ b/resources/js/routes/password/confirm/index.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -16,23 +16,44 @@ store.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:51
+ * @route '/user/confirm-password'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const confirm = {
     store: Object.assign(store, store),
 }

--- a/resources/js/routes/password/index.ts
+++ b/resources/js/routes/password/index.ts
@@ -1,11 +1,11 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../wayfinder'
 import confirmD7e05f from './confirm'
 import force from './force'
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::request
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
 export const request = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: request.url(options),
     method: 'get',
@@ -18,38 +18,72 @@ request.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::request
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
 request.url = (options?: RouteQueryOptions) => {
     return request.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::request
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
 request.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: request.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::request
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
 request.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: request.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::request
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
+    const requestForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: request.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::request
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
+        requestForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: request.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::request
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:22
+ * @route '/forgot-password'
+ */
+        requestForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: request.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    request.form = requestForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::reset
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
-* @route '/reset-password/{token}'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
 export const reset = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: reset.url(args, options),
     method: 'get',
@@ -62,25 +96,26 @@ reset.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::reset
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
-* @route '/reset-password/{token}'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
 reset.url = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { token: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            token: args[0],
-        }
+                    token: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        token: args.token,
-    }
+                        token: args.token,
+                }
 
     return reset.definition.url
             .replace('{token}', parsedArgs.token.toString())
@@ -89,29 +124,63 @@ reset.url = (args: { token: string | number } | [token: string | number ] | stri
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::reset
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
-* @route '/reset-password/{token}'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
 reset.get = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: reset.url(args, options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::reset
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
-* @route '/reset-password/{token}'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
 reset.head = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: reset.url(args, options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::reset
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
+    const resetForm = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: reset.url(args, options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::reset
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
+        resetForm.get = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: reset.url(args, options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::reset
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:44
+ * @route '/reset-password/{token}'
+ */
+        resetForm.head = (args: { token: string | number } | [token: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: reset.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    reset.form = resetForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::email
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
 export const email = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: email.url(options),
     method: 'post',
@@ -124,28 +193,49 @@ email.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::email
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
 email.url = (options?: RouteQueryOptions) => {
     return email.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::email
-* @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
-* @route '/forgot-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
 email.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: email.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::email
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
+    const emailForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: email.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\PasswordResetLinkController::email
+ * @see vendor/laravel/fortify/src/Http/Controllers/PasswordResetLinkController.php:30
+ * @route '/forgot-password'
+ */
+        emailForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: email.url(options),
+            method: 'post',
+        })
+    
+    email.form = emailForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::update
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
-* @route '/reset-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
 export const update = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: update.url(options),
     method: 'post',
@@ -158,28 +248,49 @@ update.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::update
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
-* @route '/reset-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
 update.url = (options?: RouteQueryOptions) => {
     return update.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\NewPasswordController::update
-* @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
-* @route '/reset-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
 update.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: update.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::update
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
+    const updateForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\NewPasswordController::update
+ * @see vendor/laravel/fortify/src/Http/Controllers/NewPasswordController.php:55
+ * @route '/reset-password'
+ */
+        updateForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update.url(options),
+            method: 'post',
+        })
+    
+    update.form = updateForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::confirm
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
 export const confirm = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: confirm.url(options),
     method: 'get',
@@ -192,38 +303,72 @@ confirm.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::confirm
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
 confirm.url = (options?: RouteQueryOptions) => {
     return confirm.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::confirm
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
 confirm.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: confirm.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::confirm
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
-* @route '/user/confirm-password'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
 confirm.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: confirm.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::confirm
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
+    const confirmForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: confirm.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::confirm
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
+        confirmForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: confirm.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmablePasswordController::confirm
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmablePasswordController.php:40
+ * @route '/user/confirm-password'
+ */
+        confirmForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: confirm.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    confirm.form = confirmForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::confirmation
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
-* @route '/user/confirmed-password-status'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
 export const confirmation = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: confirmation.url(options),
     method: 'get',
@@ -236,41 +381,75 @@ confirmation.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::confirmation
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
-* @route '/user/confirmed-password-status'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
 confirmation.url = (options?: RouteQueryOptions) => {
     return confirmation.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::confirmation
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
-* @route '/user/confirmed-password-status'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
 confirmation.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: confirmation.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::confirmation
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
-* @route '/user/confirmed-password-status'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
 confirmation.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: confirmation.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::confirmation
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
+    const confirmationForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: confirmation.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::confirmation
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
+        confirmationForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: confirmation.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedPasswordStatusController::confirmation
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedPasswordStatusController.php:17
+ * @route '/user/confirmed-password-status'
+ */
+        confirmationForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: confirmation.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    confirmation.form = confirmationForm
 const password = {
     request: Object.assign(request, request),
-    reset: Object.assign(reset, reset),
-    email: Object.assign(email, email),
-    update: Object.assign(update, update),
-    confirm: Object.assign(confirm, confirmD7e05f),
-    confirmation: Object.assign(confirmation, confirmation),
-    force: Object.assign(force, force),
+reset: Object.assign(reset, reset),
+email: Object.assign(email, email),
+update: Object.assign(update, update),
+confirm: Object.assign(confirm, confirmD7e05f),
+confirmation: Object.assign(confirmation, confirmation),
+force: Object.assign(force, force),
 }
 
 export default password

--- a/resources/js/routes/profile/index.ts
+++ b/resources/js/routes/profile/index.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::edit
-* @see app/Modules/Settings/Controllers/ProfileController.php:22
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:22
+ * @route '/settings/profile'
+ */
 export const edit = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(options),
     method: 'get',
@@ -16,38 +16,72 @@ edit.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::edit
-* @see app/Modules/Settings/Controllers/ProfileController.php:22
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:22
+ * @route '/settings/profile'
+ */
 edit.url = (options?: RouteQueryOptions) => {
     return edit.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::edit
-* @see app/Modules/Settings/Controllers/ProfileController.php:22
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:22
+ * @route '/settings/profile'
+ */
 edit.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::edit
-* @see app/Modules/Settings/Controllers/ProfileController.php:22
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:22
+ * @route '/settings/profile'
+ */
 edit.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: edit.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\ProfileController::edit
+ * @see app/Modules/Settings/Controllers/ProfileController.php:22
+ * @route '/settings/profile'
+ */
+    const editForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: edit.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\ProfileController::edit
+ * @see app/Modules/Settings/Controllers/ProfileController.php:22
+ * @route '/settings/profile'
+ */
+        editForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Settings\Controllers\ProfileController::edit
+ * @see app/Modules/Settings/Controllers/ProfileController.php:22
+ * @route '/settings/profile'
+ */
+        editForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    edit.form = editForm
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::update
-* @see app/Modules/Settings/Controllers/ProfileController.php:35
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:35
+ * @route '/settings/profile'
+ */
 export const update = (options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: update.url(options),
     method: 'patch',
@@ -60,28 +94,59 @@ update.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::update
-* @see app/Modules/Settings/Controllers/ProfileController.php:35
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:35
+ * @route '/settings/profile'
+ */
 update.url = (options?: RouteQueryOptions) => {
     return update.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::update
-* @see app/Modules/Settings/Controllers/ProfileController.php:35
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:35
+ * @route '/settings/profile'
+ */
 update.patch = (options?: RouteQueryOptions): RouteDefinition<'patch'> => ({
     url: update.url(options),
     method: 'patch',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\ProfileController::update
+ * @see app/Modules/Settings/Controllers/ProfileController.php:35
+ * @route '/settings/profile'
+ */
+    const updateForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update.url({
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PATCH',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\ProfileController::update
+ * @see app/Modules/Settings/Controllers/ProfileController.php:35
+ * @route '/settings/profile'
+ */
+        updateForm.patch = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PATCH',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update.form = updateForm
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::destroy
-* @see app/Modules/Settings/Controllers/ProfileController.php:86
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:86
+ * @route '/settings/profile'
+ */
 export const destroy = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: destroy.url(options),
     method: 'delete',
@@ -94,28 +159,59 @@ destroy.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::destroy
-* @see app/Modules/Settings/Controllers/ProfileController.php:86
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:86
+ * @route '/settings/profile'
+ */
 destroy.url = (options?: RouteQueryOptions) => {
     return destroy.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::destroy
-* @see app/Modules/Settings/Controllers/ProfileController.php:86
-* @route '/settings/profile'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:86
+ * @route '/settings/profile'
+ */
 destroy.delete = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: destroy.url(options),
     method: 'delete',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\ProfileController::destroy
+ * @see app/Modules/Settings/Controllers/ProfileController.php:86
+ * @route '/settings/profile'
+ */
+    const destroyForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: destroy.url({
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\ProfileController::destroy
+ * @see app/Modules/Settings/Controllers/ProfileController.php:86
+ * @route '/settings/profile'
+ */
+        destroyForm.delete = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: destroy.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    destroy.form = destroyForm
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::requestDeletion
-* @see app/Modules/Settings/Controllers/ProfileController.php:111
-* @route '/settings/profile/deletion-request'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:111
+ * @route '/settings/profile/deletion-request'
+ */
 export const requestDeletion = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: requestDeletion.url(options),
     method: 'post',
@@ -128,28 +224,49 @@ requestDeletion.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::requestDeletion
-* @see app/Modules/Settings/Controllers/ProfileController.php:111
-* @route '/settings/profile/deletion-request'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:111
+ * @route '/settings/profile/deletion-request'
+ */
 requestDeletion.url = (options?: RouteQueryOptions) => {
     return requestDeletion.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::requestDeletion
-* @see app/Modules/Settings/Controllers/ProfileController.php:111
-* @route '/settings/profile/deletion-request'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:111
+ * @route '/settings/profile/deletion-request'
+ */
 requestDeletion.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: requestDeletion.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\ProfileController::requestDeletion
+ * @see app/Modules/Settings/Controllers/ProfileController.php:111
+ * @route '/settings/profile/deletion-request'
+ */
+    const requestDeletionForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: requestDeletion.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\ProfileController::requestDeletion
+ * @see app/Modules/Settings/Controllers/ProfileController.php:111
+ * @route '/settings/profile/deletion-request'
+ */
+        requestDeletionForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: requestDeletion.url(options),
+            method: 'post',
+        })
+    
+    requestDeletion.form = requestDeletionForm
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::cancelDeletion
-* @see app/Modules/Settings/Controllers/ProfileController.php:129
-* @route '/settings/profile/deletion-request/cancel'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:129
+ * @route '/settings/profile/deletion-request/cancel'
+ */
 export const cancelDeletion = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: cancelDeletion.url(options),
     method: 'post',
@@ -162,29 +279,50 @@ cancelDeletion.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::cancelDeletion
-* @see app/Modules/Settings/Controllers/ProfileController.php:129
-* @route '/settings/profile/deletion-request/cancel'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:129
+ * @route '/settings/profile/deletion-request/cancel'
+ */
 cancelDeletion.url = (options?: RouteQueryOptions) => {
     return cancelDeletion.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\ProfileController::cancelDeletion
-* @see app/Modules/Settings/Controllers/ProfileController.php:129
-* @route '/settings/profile/deletion-request/cancel'
-*/
+ * @see app/Modules/Settings/Controllers/ProfileController.php:129
+ * @route '/settings/profile/deletion-request/cancel'
+ */
 cancelDeletion.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: cancelDeletion.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\ProfileController::cancelDeletion
+ * @see app/Modules/Settings/Controllers/ProfileController.php:129
+ * @route '/settings/profile/deletion-request/cancel'
+ */
+    const cancelDeletionForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: cancelDeletion.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\ProfileController::cancelDeletion
+ * @see app/Modules/Settings/Controllers/ProfileController.php:129
+ * @route '/settings/profile/deletion-request/cancel'
+ */
+        cancelDeletionForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: cancelDeletion.url(options),
+            method: 'post',
+        })
+    
+    cancelDeletion.form = cancelDeletionForm
 const profile = {
     edit: Object.assign(edit, edit),
-    update: Object.assign(update, update),
-    destroy: Object.assign(destroy, destroy),
-    requestDeletion: Object.assign(requestDeletion, requestDeletion),
-    cancelDeletion: Object.assign(cancelDeletion, cancelDeletion),
+update: Object.assign(update, update),
+destroy: Object.assign(destroy, destroy),
+requestDeletion: Object.assign(requestDeletion, requestDeletion),
+cancelDeletion: Object.assign(cancelDeletion, cancelDeletion),
 }
 
 export default profile

--- a/resources/js/routes/register/index.ts
+++ b/resources/js/routes/register/index.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -16,23 +16,44 @@ store.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
-* @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
-* @route '/register'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RegisteredUserController::store
+ * @see vendor/laravel/fortify/src/Http/Controllers/RegisteredUserController.php:53
+ * @route '/register'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const register = {
     store: Object.assign(store, store),
 }

--- a/resources/js/routes/security/index.ts
+++ b/resources/js/routes/security/index.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::edit
-* @see app/Modules/Settings/Controllers/SecurityController.php:38
-* @route '/settings/security'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
 export const edit = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(options),
     method: 'get',
@@ -16,33 +16,67 @@ edit.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::edit
-* @see app/Modules/Settings/Controllers/SecurityController.php:38
-* @route '/settings/security'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
 edit.url = (options?: RouteQueryOptions) => {
     return edit.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::edit
-* @see app/Modules/Settings/Controllers/SecurityController.php:38
-* @route '/settings/security'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
 edit.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: edit.url(options),
     method: 'get',
 })
-
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::edit
-* @see app/Modules/Settings/Controllers/SecurityController.php:38
-* @route '/settings/security'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
 edit.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: edit.url(options),
     method: 'head',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\SecurityController::edit
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
+    const editForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: edit.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\SecurityController::edit
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
+        editForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit.url(options),
+            method: 'get',
+        })
+            /**
+* @see \App\Modules\Settings\Controllers\SecurityController::edit
+ * @see app/Modules/Settings/Controllers/SecurityController.php:38
+ * @route '/settings/security'
+ */
+        editForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: edit.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    edit.form = editForm
 const security = {
     edit: Object.assign(edit, edit),
 }

--- a/resources/js/routes/storage/index.ts
+++ b/resources/js/routes/storage/index.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../wayfinder'
 import localA91488 from './local'
 /**
-* @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
-* @route '/storage/{path}'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
+ * @route '/storage/{path}'
+ */
 export const local = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: local.url(args, options),
     method: 'get',
@@ -15,25 +15,26 @@ local.definition = {
 } satisfies RouteDefinition<["get","head"]>
 
 /**
-* @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
-* @route '/storage/{path}'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
+ * @route '/storage/{path}'
+ */
 local.url = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { path: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            path: args[0],
-        }
+                    path: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        path: args.path,
-    }
+                        path: args.path,
+                }
 
     return local.definition.url
             .replace('{path}', parsedArgs.path.toString())
@@ -41,23 +42,54 @@ local.url = (args: { path: string | number } | [path: string | number ] | string
 }
 
 /**
-* @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
-* @route '/storage/{path}'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
+ * @route '/storage/{path}'
+ */
 local.get = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: local.url(args, options),
     method: 'get',
 })
-
 /**
-* @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
-* @route '/storage/{path}'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
+ * @route '/storage/{path}'
+ */
 local.head = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: local.url(args, options),
     method: 'head',
 })
 
+    /**
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
+ * @route '/storage/{path}'
+ */
+    const localForm = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: local.url(args, options),
+        method: 'get',
+    })
+
+            /**
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
+ * @route '/storage/{path}'
+ */
+        localForm.get = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: local.url(args, options),
+            method: 'get',
+        })
+            /**
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:98
+ * @route '/storage/{path}'
+ */
+        localForm.head = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: local.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    local.form = localForm
 const storage = {
     local: Object.assign(local, localA91488),
 }

--- a/resources/js/routes/storage/local/index.ts
+++ b/resources/js/routes/storage/local/index.ts
@@ -1,8 +1,8 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, applyUrlDefaults } from './../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../wayfinder'
 /**
-* @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:106
-* @route '/storage/{path}'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:106
+ * @route '/storage/{path}'
+ */
 export const upload = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: upload.url(args, options),
     method: 'put',
@@ -14,25 +14,26 @@ upload.definition = {
 } satisfies RouteDefinition<["put"]>
 
 /**
-* @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:106
-* @route '/storage/{path}'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:106
+ * @route '/storage/{path}'
+ */
 upload.url = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions) => {
     if (typeof args === 'string' || typeof args === 'number') {
         args = { path: args }
     }
 
+    
     if (Array.isArray(args)) {
         args = {
-            path: args[0],
-        }
+                    path: args[0],
+                }
     }
 
     args = applyUrlDefaults(args)
 
     const parsedArgs = {
-        path: args.path,
-    }
+                        path: args.path,
+                }
 
     return upload.definition.url
             .replace('{path}', parsedArgs.path.toString())
@@ -40,14 +41,43 @@ upload.url = (args: { path: string | number } | [path: string | number ] | strin
 }
 
 /**
-* @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:106
-* @route '/storage/{path}'
-*/
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:106
+ * @route '/storage/{path}'
+ */
 upload.put = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: upload.url(args, options),
     method: 'put',
 })
 
+    /**
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:106
+ * @route '/storage/{path}'
+ */
+    const uploadForm = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: upload.url(args, {
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+ * @see vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemServiceProvider.php:106
+ * @route '/storage/{path}'
+ */
+        uploadForm.put = (args: { path: string | number } | [path: string | number ] | string | number, options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: upload.url(args, {
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    upload.form = uploadForm
 const local = {
     upload: Object.assign(upload, upload),
 }

--- a/resources/js/routes/two-factor/index.ts
+++ b/resources/js/routes/two-factor/index.ts
@@ -1,10 +1,10 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 import loginDf2c2a from './login'
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::login
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
-* @route '/two-factor-challenge'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
 export const login = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: login.url(options),
     method: 'get',
@@ -17,38 +17,72 @@ login.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::login
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
-* @route '/two-factor-challenge'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
 login.url = (options?: RouteQueryOptions) => {
     return login.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::login
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
-* @route '/two-factor-challenge'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
 login.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: login.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::login
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
-* @route '/two-factor-challenge'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
 login.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: login.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::login
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
+    const loginForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: login.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::login
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
+        loginForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: login.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticatedSessionController::login
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticatedSessionController.php:41
+ * @route '/two-factor-challenge'
+ */
+        loginForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: login.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    login.form = loginForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::enable
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
 export const enable = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: enable.url(options),
     method: 'post',
@@ -61,28 +95,49 @@ enable.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::enable
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
 enable.url = (options?: RouteQueryOptions) => {
     return enable.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::enable
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
 enable.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: enable.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::enable
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
+    const enableForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: enable.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::enable
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:21
+ * @route '/user/two-factor-authentication'
+ */
+        enableForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: enable.url(options),
+            method: 'post',
+        })
+    
+    enable.form = enableForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::confirm
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
-* @route '/user/confirmed-two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
 export const confirm = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: confirm.url(options),
     method: 'post',
@@ -95,28 +150,49 @@ confirm.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::confirm
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
-* @route '/user/confirmed-two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
 confirm.url = (options?: RouteQueryOptions) => {
     return confirm.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::confirm
-* @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
-* @route '/user/confirmed-two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
 confirm.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: confirm.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::confirm
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
+    const confirmForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: confirm.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\ConfirmedTwoFactorAuthenticationController::confirm
+ * @see vendor/laravel/fortify/src/Http/Controllers/ConfirmedTwoFactorAuthenticationController.php:19
+ * @route '/user/confirmed-two-factor-authentication'
+ */
+        confirmForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: confirm.url(options),
+            method: 'post',
+        })
+    
+    confirm.form = confirmForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::disable
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
 export const disable = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: disable.url(options),
     method: 'delete',
@@ -129,28 +205,59 @@ disable.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::disable
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
 disable.url = (options?: RouteQueryOptions) => {
     return disable.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::disable
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
-* @route '/user/two-factor-authentication'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
 disable.delete = (options?: RouteQueryOptions): RouteDefinition<'delete'> => ({
     url: disable.url(options),
     method: 'delete',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::disable
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
+    const disableForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: disable.url({
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'DELETE',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorAuthenticationController::disable
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorAuthenticationController.php:35
+ * @route '/user/two-factor-authentication'
+ */
+        disableForm.delete = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: disable.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'DELETE',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    disable.form = disableForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::qrCode
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
-* @route '/user/two-factor-qr-code'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
 export const qrCode = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: qrCode.url(options),
     method: 'get',
@@ -163,38 +270,72 @@ qrCode.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::qrCode
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
-* @route '/user/two-factor-qr-code'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
 qrCode.url = (options?: RouteQueryOptions) => {
     return qrCode.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::qrCode
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
-* @route '/user/two-factor-qr-code'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
 qrCode.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: qrCode.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::qrCode
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
-* @route '/user/two-factor-qr-code'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
 qrCode.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: qrCode.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::qrCode
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
+    const qrCodeForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: qrCode.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::qrCode
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
+        qrCodeForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: qrCode.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorQrCodeController::qrCode
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorQrCodeController.php:16
+ * @route '/user/two-factor-qr-code'
+ */
+        qrCodeForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: qrCode.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    qrCode.form = qrCodeForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::secretKey
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
-* @route '/user/two-factor-secret-key'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
 export const secretKey = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: secretKey.url(options),
     method: 'get',
@@ -207,38 +348,72 @@ secretKey.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::secretKey
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
-* @route '/user/two-factor-secret-key'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
 secretKey.url = (options?: RouteQueryOptions) => {
     return secretKey.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::secretKey
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
-* @route '/user/two-factor-secret-key'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
 secretKey.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: secretKey.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::secretKey
-* @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
-* @route '/user/two-factor-secret-key'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
 secretKey.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: secretKey.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::secretKey
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
+    const secretKeyForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: secretKey.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::secretKey
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
+        secretKeyForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: secretKey.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\TwoFactorSecretKeyController::secretKey
+ * @see vendor/laravel/fortify/src/Http/Controllers/TwoFactorSecretKeyController.php:17
+ * @route '/user/two-factor-secret-key'
+ */
+        secretKeyForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: secretKey.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    secretKey.form = secretKeyForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::recoveryCodes
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
 export const recoveryCodes = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: recoveryCodes.url(options),
     method: 'get',
@@ -251,38 +426,72 @@ recoveryCodes.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::recoveryCodes
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
 recoveryCodes.url = (options?: RouteQueryOptions) => {
     return recoveryCodes.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::recoveryCodes
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
 recoveryCodes.get = (options?: RouteQueryOptions): RouteDefinition<'get'> => ({
     url: recoveryCodes.url(options),
     method: 'get',
 })
-
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::recoveryCodes
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
 recoveryCodes.head = (options?: RouteQueryOptions): RouteDefinition<'head'> => ({
     url: recoveryCodes.url(options),
     method: 'head',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::recoveryCodes
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
+    const recoveryCodesForm = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+        action: recoveryCodes.url(options),
+        method: 'get',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::recoveryCodes
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
+        recoveryCodesForm.get = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: recoveryCodes.url(options),
+            method: 'get',
+        })
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::recoveryCodes
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:19
+ * @route '/user/two-factor-recovery-codes'
+ */
+        recoveryCodesForm.head = (options?: RouteQueryOptions): RouteFormDefinition<'get'> => ({
+            action: recoveryCodes.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'HEAD',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'get',
+        })
+    
+    recoveryCodes.form = recoveryCodesForm
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::regenerateRecoveryCodes
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
 export const regenerateRecoveryCodes = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: regenerateRecoveryCodes.url(options),
     method: 'post',
@@ -295,32 +504,53 @@ regenerateRecoveryCodes.definition = {
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::regenerateRecoveryCodes
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
 regenerateRecoveryCodes.url = (options?: RouteQueryOptions) => {
     return regenerateRecoveryCodes.definition.url + queryParams(options)
 }
 
 /**
 * @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::regenerateRecoveryCodes
-* @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
-* @route '/user/two-factor-recovery-codes'
-*/
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
 regenerateRecoveryCodes.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: regenerateRecoveryCodes.url(options),
     method: 'post',
 })
 
+    /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::regenerateRecoveryCodes
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
+    const regenerateRecoveryCodesForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: regenerateRecoveryCodes.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \Laravel\Fortify\Http\Controllers\RecoveryCodeController::regenerateRecoveryCodes
+ * @see vendor/laravel/fortify/src/Http/Controllers/RecoveryCodeController.php:38
+ * @route '/user/two-factor-recovery-codes'
+ */
+        regenerateRecoveryCodesForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: regenerateRecoveryCodes.url(options),
+            method: 'post',
+        })
+    
+    regenerateRecoveryCodes.form = regenerateRecoveryCodesForm
 const twoFactor = {
     login: Object.assign(login, loginDf2c2a),
-    enable: Object.assign(enable, enable),
-    confirm: Object.assign(confirm, confirm),
-    disable: Object.assign(disable, disable),
-    qrCode: Object.assign(qrCode, qrCode),
-    secretKey: Object.assign(secretKey, secretKey),
-    recoveryCodes: Object.assign(recoveryCodes, recoveryCodes),
-    regenerateRecoveryCodes: Object.assign(regenerateRecoveryCodes, regenerateRecoveryCodes),
+enable: Object.assign(enable, enable),
+confirm: Object.assign(confirm, confirm),
+disable: Object.assign(disable, disable),
+qrCode: Object.assign(qrCode, qrCode),
+secretKey: Object.assign(secretKey, secretKey),
+recoveryCodes: Object.assign(recoveryCodes, recoveryCodes),
+regenerateRecoveryCodes: Object.assign(regenerateRecoveryCodes, regenerateRecoveryCodes),
 }
 
 export default twoFactor

--- a/resources/js/routes/two-factor/login/index.ts
+++ b/resources/js/routes/two-factor/login/index.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../wayfinder'
 /**
 * @see \App\Modules\WorkOs\Controllers\Auth\TwoFactorChallengeController::store
-* @see app/Modules/WorkOs/Controllers/Auth/TwoFactorChallengeController.php:26
-* @route '/two-factor-challenge'
-*/
+ * @see app/Modules/WorkOs/Controllers/Auth/TwoFactorChallengeController.php:26
+ * @route '/two-factor-challenge'
+ */
 export const store = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
@@ -16,23 +16,44 @@ store.definition = {
 
 /**
 * @see \App\Modules\WorkOs\Controllers\Auth\TwoFactorChallengeController::store
-* @see app/Modules/WorkOs/Controllers/Auth/TwoFactorChallengeController.php:26
-* @route '/two-factor-challenge'
-*/
+ * @see app/Modules/WorkOs/Controllers/Auth/TwoFactorChallengeController.php:26
+ * @route '/two-factor-challenge'
+ */
 store.url = (options?: RouteQueryOptions) => {
     return store.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\WorkOs\Controllers\Auth\TwoFactorChallengeController::store
-* @see app/Modules/WorkOs/Controllers/Auth/TwoFactorChallengeController.php:26
-* @route '/two-factor-challenge'
-*/
+ * @see app/Modules/WorkOs/Controllers/Auth/TwoFactorChallengeController.php:26
+ * @route '/two-factor-challenge'
+ */
 store.post = (options?: RouteQueryOptions): RouteDefinition<'post'> => ({
     url: store.url(options),
     method: 'post',
 })
 
+    /**
+* @see \App\Modules\WorkOs\Controllers\Auth\TwoFactorChallengeController::store
+ * @see app/Modules/WorkOs/Controllers/Auth/TwoFactorChallengeController.php:26
+ * @route '/two-factor-challenge'
+ */
+    const storeForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: store.url(options),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\WorkOs\Controllers\Auth\TwoFactorChallengeController::store
+ * @see app/Modules/WorkOs/Controllers/Auth/TwoFactorChallengeController.php:26
+ * @route '/two-factor-challenge'
+ */
+        storeForm.post = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: store.url(options),
+            method: 'post',
+        })
+    
+    store.form = storeForm
 const login = {
     store: Object.assign(store, store),
 }

--- a/resources/js/routes/user-password/index.ts
+++ b/resources/js/routes/user-password/index.ts
@@ -1,9 +1,9 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition } from './../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../wayfinder'
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::update
-* @see app/Modules/Settings/Controllers/SecurityController.php:72
-* @route '/settings/password'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
 export const update = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(options),
     method: 'put',
@@ -16,23 +16,54 @@ update.definition = {
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::update
-* @see app/Modules/Settings/Controllers/SecurityController.php:72
-* @route '/settings/password'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
 update.url = (options?: RouteQueryOptions) => {
     return update.definition.url + queryParams(options)
 }
 
 /**
 * @see \App\Modules\Settings\Controllers\SecurityController::update
-* @see app/Modules/Settings/Controllers/SecurityController.php:72
-* @route '/settings/password'
-*/
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
 update.put = (options?: RouteQueryOptions): RouteDefinition<'put'> => ({
     url: update.url(options),
     method: 'put',
 })
 
+    /**
+* @see \App\Modules\Settings\Controllers\SecurityController::update
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
+    const updateForm = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+        action: update.url({
+                    [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                        _method: 'PUT',
+                        ...(options?.query ?? options?.mergeQuery ?? {}),
+                    }
+                }),
+        method: 'post',
+    })
+
+            /**
+* @see \App\Modules\Settings\Controllers\SecurityController::update
+ * @see app/Modules/Settings/Controllers/SecurityController.php:72
+ * @route '/settings/password'
+ */
+        updateForm.put = (options?: RouteQueryOptions): RouteFormDefinition<'post'> => ({
+            action: update.url({
+                        [options?.mergeQuery ? 'mergeQuery' : 'query']: {
+                            _method: 'PUT',
+                            ...(options?.query ?? options?.mergeQuery ?? {}),
+                        }
+                    }),
+            method: 'post',
+        })
+    
+    update.form = updateForm
 const userPassword = {
     update: Object.assign(update, update),
 }


### PR DESCRIPTION
## Summary\n- Fix FAST mahasiswa module entry so portal redirects to existing Inertia pages.\n- Align dashboard/submission page names and base paths with the current Mahasiswa wrappers.\n- Add the missing mahasiswa Ajukan wrapper page.\n\n## Validation\n- npm run lint\n- vendor/bin/phpstan analyse --memory-limit=1G\n- php artisan test\n- composer lint:check\n- composer audit (blocked locally by Packagist network access)\n- php artisan wayfinder:generate\n- ENABLE_WAYFINDER=1 npm run build