### PR TITLE
fix(docker): auto-seed roles, permissions, modules on container start

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -136,6 +136,19 @@ if [ "${RUN_MIGRATIONS:-true}" = "true" ]; then
     php artisan migrate --force
 fi
 
+# Seed essential reference data (roles, modules, permissions, radar rules, portal settings).
+# All seeders are fully idempotent (firstOrCreate / syncWithoutDetaching / count-guard),
+# so this block is safe to run on every container start without duplicating data.
+# Set RUN_SEEDER=false in your environment to skip (e.g. during testing or manual overrides).
+if [ "${RUN_SEEDER:-true}" = "true" ]; then
+    echo "Seeding essential data (roles, modules, permissions, radar, portal settings)..."
+    php artisan db:seed --class=ModuleSeeder --force --no-interaction || true
+    php artisan db:seed --class=PermissionSeeder --force --no-interaction || true
+    php artisan db:seed --class=RadarSeeder --force --no-interaction || true
+    php artisan db:seed --class=PortalSettingSeeder --force --no-interaction || true
+    echo "Essential data seeding complete."
+fi
+
 # Register Laravel scheduler cron job
 echo "Configuring Laravel scheduler cron job..."
 echo "* * * * * cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1" > /etc/crontabs/root


### PR DESCRIPTION
- Add idempotent seeding block to entrypoint.sh after migrations
- Seeds: ModuleSeeder (roles + modules), PermissionSeeder (permissions + pivot), RadarSeeder (radar protections), PortalSettingSeeder (portal defaults)
- All seeders use firstOrCreate/syncWithoutDetaching/count-guard — safe to run on every deploy without duplicating data
- Controlled via RUN_SEEDER env var (default: true)
- Fixes empty Authorization data (roles, permissions, access control matrix) in production deployments

## Deskripsi Perubahan (PR)

Jelaskan secara ringkas perubahan apa saja yang diajukan dalam Pull Request ini dan masalah apa yang diselesaikannya.

---

## Jenis Perubahan
*Silakan centang opsi yang sesuai dengan memberikan tanda [x] pada kotak:*
- [ ] 🐛 Perbaikan Bug (Bug Fix - perbaikan yang tidak merusak fitur yang ada)
- [ ] 🚀 Fitur Baru (New Feature - penambahan modul/fungsionalitas baru)
- [ ] 🔨 Refaktor / Pembersihan Kode (Refactoring)
- [ ] 📦 Pembaruan Dependency (Library Update)
- [ ] 🛡️ Konfigurasi Keamanan atau CI/CD (Security / DevOps)

---

## Daftar Tugas Selesai (Checklist)
- [ ] Kode sudah diuji secara lokal (local testing) dan berjalan dengan baik.
- [ ] Sintaks PHP sudah dirapikan (`composer lint`) dan frontend sudah diformat (`npm run lint`).
- [ ] Tidak ada warning/error baru yang muncul di console browser.
- [ ] Migrasi database (jika ada) sudah diuji naik-turun (`migrate` & `rollback`).

---

## Bukti Pengujian (Screenshots/Recordings)
*Tautkan screenshot atau video rekaman dari perubahan UI/fitur di sini jika ada:*
> (Tulis detail atau drag & drop gambar di sini)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic startup data seeding for modules, permissions, radar settings, and portal settings.
  * Seeding can be disabled by setting `RUN_SEEDER=false`.
  * Startup continues even if an individual seeding task fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->